### PR TITLE
Comment out c-ares/CMakeFiles exclude

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
                 "./c-ares/windows_port.c",
                 // FIXME: find a better way to exclude `CMakeFiles` dir if it exists. Users don't have
                 // this dir locally and this line causes a SwiftPM warning about invalid exclude.
-                //"./c-ares/CMakeFiles/",
+                // "./c-ares/CMakeFiles/",
                 "./c-ares/test/",
             ],
             sources: ["./c-ares"],


### PR DESCRIPTION
Motivation:
`c-ares/CMakeFiles` dir doesn't exist unless cmake is run locally. The exclude line causes SwiftPM warning about invalid exclude.

Modification:
Comment out the exclusion for now. We should find better way to exclude the dir only if it exists.