### PR TITLE
Fix bug in DNSSD IPv6 address string conversion.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ var caresExclude = [
 ]
 
 do {
-    if !(try FileManager.default.contentsOfDirectory(atPath: "./Sources/CAsyncDNSResolver/c-ares/CMakeFiles").isEmpty) {
+    if try !(FileManager.default.contentsOfDirectory(atPath: "./Sources/CAsyncDNSResolver/c-ares/CMakeFiles").isEmpty) {
         caresExclude.append("./c-ares/CMakeFiles/")
     }
 } catch {

--- a/Sources/AsyncDNSResolver/AsyncDNSResolver.swift
+++ b/Sources/AsyncDNSResolver/AsyncDNSResolver.swift
@@ -26,7 +26,7 @@ public struct AsyncDNSResolver {
         #if canImport(Darwin)
         self.init(DNSSDDNSResolver())
         #else
-        self.init(try CAresDNSResolver())
+        try self.init(CAresDNSResolver())
         #endif
     }
 
@@ -44,7 +44,7 @@ public struct AsyncDNSResolver {
     /// - Parameters:
     ///   - options: Options to create ``CAresDNSResolver`` with.
     public init(options: CAresDNSResolver.Options) throws {
-        self.init(try CAresDNSResolver(options: options))
+        try self.init(CAresDNSResolver(options: options))
     }
 
     /// See ``DNSResolver/queryA(name:)``.

--- a/Sources/AsyncDNSResolver/dnssd/DNSResolver_dnssd.swift
+++ b/Sources/AsyncDNSResolver/dnssd/DNSResolver_dnssd.swift
@@ -220,6 +220,10 @@ extension DNSSD {
                 throw AsyncDNSResolver.Error.noData()
             }
 
+            guard length >= MemoryLayout<in_addr>.size else {
+               throw AsyncDNSResolver.Error.badResponse()
+            }
+
             var parsedAddressBytes = [CChar](repeating: 0, count: Int(INET_ADDRSTRLEN))
             inet_ntop(AF_INET, ptr, &parsedAddressBytes, socklen_t(INET_ADDRSTRLEN))
             let parsedAddress = String(cString: parsedAddressBytes)
@@ -237,6 +241,10 @@ extension DNSSD {
         func parseRecord(data: UnsafeRawPointer?, length: UInt16) throws -> AAAARecord {
             guard let ptr = data?.assumingMemoryBound(to: UInt8.self) else {
                 throw AsyncDNSResolver.Error.noData()
+            }
+
+            guard length >= MemoryLayout<in6_addr>.size else {
+               throw AsyncDNSResolver.Error.badResponse()
             }
 
             var parsedAddressBytes = [CChar](repeating: 0, count: Int(INET6_ADDRSTRLEN))

--- a/Sources/AsyncDNSResolver/dnssd/DNSResolver_dnssd.swift
+++ b/Sources/AsyncDNSResolver/dnssd/DNSResolver_dnssd.swift
@@ -221,7 +221,7 @@ extension DNSSD {
             }
 
             guard length >= MemoryLayout<in_addr>.size else {
-               throw AsyncDNSResolver.Error.badResponse()
+                throw AsyncDNSResolver.Error.badResponse()
             }
 
             var parsedAddressBytes = [CChar](repeating: 0, count: Int(INET_ADDRSTRLEN))
@@ -244,7 +244,7 @@ extension DNSSD {
             }
 
             guard length >= MemoryLayout<in6_addr>.size else {
-               throw AsyncDNSResolver.Error.badResponse()
+                throw AsyncDNSResolver.Error.badResponse()
             }
 
             var parsedAddressBytes = [CChar](repeating: 0, count: Int(INET6_ADDRSTRLEN))

--- a/Tests/AsyncDNSResolverTests/dnssd/DNSSDDNSResolverTests.swift
+++ b/Tests/AsyncDNSResolverTests/dnssd/DNSSDDNSResolverTests.swift
@@ -112,11 +112,25 @@ final class DNSSDDNSResolverTests: XCTestCase {
         }
     }
 
-    func test_parseAAAA() throws {
-        let addrBytes: [UInt8] = [38, 32, 1, 73, 17, 11, 71, 14, 0, 0, 0, 0, 0, 0, 14, 26]
+    func test_parseATooShort() throws {
+        let addrBytes: [UInt8] = [38, 32, 1]
         try addrBytes.withUnsafeBufferPointer {
-            let record = try DNSSD.AAAAQueryReplyHandler.instance.parseRecord(data: $0.baseAddress, length: UInt16($0.count))
-            XCTAssertEqual(record, AAAARecord(address: .IPv6("2620:149:110b:470e::e1a"), ttl: nil))
+            XCTAssertThrowsError(
+                try DNSSD.AQueryReplyHandler.instance.parseRecord(
+                    data: $0.baseAddress, length: UInt16($0.count)
+                )
+            )
+        }
+    }
+
+    func test_parseAAAATooShort() throws {
+        let addrBytes: [UInt8] = [38, 32, 1, 73, 17, 11, 71, 14, 0, 0, 0, 0, 0, 0, 14]
+        try addrBytes.withUnsafeBufferPointer {
+            XCTAssertThrowsError(
+                try DNSSD.AAAAQueryReplyHandler.instance.parseRecord(
+                    data: $0.baseAddress, length: UInt16($0.count)
+                )
+            )
         }
     }
 

--- a/Tests/AsyncDNSResolverTests/dnssd/DNSSDDNSResolverTests.swift
+++ b/Tests/AsyncDNSResolverTests/dnssd/DNSSDDNSResolverTests.swift
@@ -104,6 +104,22 @@ final class DNSSDDNSResolverTests: XCTestCase {
         XCTAssertFalse(reply.isEmpty, "should have SRV record(s)")
     }
 
+    func test_parseA() throws {
+        let addrBytes: [UInt8] = [38, 32, 1, 73]
+        try addrBytes.withUnsafeBufferPointer {
+            let record = try DNSSD.AQueryReplyHandler.instance.parseRecord(data: $0.baseAddress, length: UInt16($0.count))
+            XCTAssertEqual(record, ARecord(address: .IPv4("38.32.1.73"), ttl: nil))
+        }
+    }
+
+    func test_parseAAAA() throws {
+        let addrBytes: [UInt8] = [38, 32, 1, 73, 17, 11, 71, 14, 0, 0, 0, 0, 0, 0, 14, 26]
+        try addrBytes.withUnsafeBufferPointer {
+            let record = try DNSSD.AAAAQueryReplyHandler.instance.parseRecord(data: $0.baseAddress, length: UInt16($0.count))
+            XCTAssertEqual(record, AAAARecord(address: .IPv6("2620:149:110b:470e::e1a"), ttl: nil))
+        }
+    }
+
     func test_concurrency() async throws {
         func run(
             times: Int = 100,

--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -21,6 +21,12 @@ function replace_acceptable_years() {
     sed -e 's/202[012]-202[123]/YEARS/' -e 's/202[0123]/YEARS/'
 }
 
+if ! hash swiftformat &> /dev/null
+then
+  printf "\033[0;31mPlease install swiftformat (https://github.com/nicklockwood/SwiftFormat) and run again.\033[0m\n"
+  exit 1
+fi
+
 printf "=> Checking format... "
 FIRST_OUT="$(git status --porcelain)"
 swiftformat . > /dev/null 2>&1


### PR DESCRIPTION
The old implementation converted each byte to a hexadecimal number separately, meaning that leading zeros in a byte would be dropped even in the middle of a group.

For example, the address 2620:149:110b:470e:0:0:0:e1a was incorrectly
rendered as              2620:149:11b:47e:0:0:0:e1a, with zeros dropped
in the 3rd and 4th octets.

I figured the most robust fix would be to use inet_ntop to format the address, which produces a correctly abbreviated address like 2620:149:110b:470e::e1a. This is the approach used in DNSResolver_c-ares.swift.