### PR TITLE
Add concrete IPv4 and IPv6 types

### DIFF
--- a/Sources/AsyncDNSResolver/AsyncDNSResolver.swift
+++ b/Sources/AsyncDNSResolver/AsyncDNSResolver.swift
@@ -184,21 +184,39 @@ enum QueryType {
 // MARK: - Query reply types
 
 public enum IPAddress: Sendable, Equatable, CustomStringConvertible {
-    case IPv4(String)
-    case IPv6(String)
+    case ipv4(IPv4)
+    case ipv6(IPv6)
 
     public var description: String {
         switch self {
-        case .IPv4(let address):
-            return address
-        case .IPv6(let address):
-            return address
+        case .ipv4(let address):
+            return String(describing: address)
+        case .ipv6(let address):
+            return String(describing: address)
+        }
+    }
+
+    public struct IPv4: Sendable, Hashable, CustomStringConvertible {
+        public var address: String
+        public var description: String { self.address }
+
+        public init(address: String) {
+            self.address = address
+        }
+    }
+
+    public struct IPv6: Sendable, Hashable, CustomStringConvertible {
+        public var address: String
+        public var description: String { self.address }
+
+        public init(address: String) {
+            self.address = address
         }
     }
 }
 
 public struct ARecord: Sendable, Equatable, CustomStringConvertible {
-    public let address: IPAddress
+    public let address: IPAddress.IPv4
     public let ttl: Int32?
 
     public var description: String {
@@ -207,7 +225,7 @@ public struct ARecord: Sendable, Equatable, CustomStringConvertible {
 }
 
 public struct AAAARecord: Sendable, Equatable, CustomStringConvertible {
-    public let address: IPAddress
+    public let address: IPAddress.IPv6
     public let ttl: Int32?
 
     public var description: String {

--- a/Sources/AsyncDNSResolver/c-ares/DNSResolver_c-ares.swift
+++ b/Sources/AsyncDNSResolver/c-ares/DNSResolver_c-ares.swift
@@ -574,32 +574,34 @@ private func toStringArray(_ arrayPointer: UnsafeMutablePointer<UnsafeMutablePoi
     return result
 }
 
-extension IPAddress {
+extension IPAddress.IPv4 {
     init(_ address: in_addr) {
         var address = address
         var addressBytes = [CChar](repeating: 0, count: Int(INET_ADDRSTRLEN))
         inet_ntop(AF_INET, &address, &addressBytes, socklen_t(INET_ADDRSTRLEN))
-        self = .IPv4(String(cString: addressBytes))
+        self = .init(address: String(cString: addressBytes))
     }
+}
 
+extension IPAddress.IPv6 {
     init(_ address: ares_in6_addr) {
         var address = address
         var addressBytes = [CChar](repeating: 0, count: Int(INET6_ADDRSTRLEN))
         inet_ntop(AF_INET6, &address, &addressBytes, socklen_t(INET6_ADDRSTRLEN))
-        self = .IPv6(String(cString: addressBytes))
+        self = .init(address: String(cString: addressBytes))
     }
 }
 
 extension ARecord {
     init(_ addrttl: ares_addrttl) {
-        self.address = IPAddress(addrttl.ipaddr)
+        self.address = IPAddress.IPv4(addrttl.ipaddr)
         self.ttl = addrttl.ttl
     }
 }
 
 extension AAAARecord {
     init(_ addrttl: ares_addr6ttl) {
-        self.address = IPAddress(addrttl.ip6addr)
+        self.address = IPAddress.IPv6(addrttl.ip6addr)
         self.ttl = addrttl.ttl
     }
 }

--- a/Sources/AsyncDNSResolver/dnssd/DNSResolver_dnssd.swift
+++ b/Sources/AsyncDNSResolver/dnssd/DNSResolver_dnssd.swift
@@ -227,7 +227,7 @@ extension DNSSD {
             var parsedAddressBytes = [CChar](repeating: 0, count: Int(INET_ADDRSTRLEN))
             inet_ntop(AF_INET, ptr, &parsedAddressBytes, socklen_t(INET_ADDRSTRLEN))
             let parsedAddress = String(cString: parsedAddressBytes)
-            return ARecord(address: .IPv4(parsedAddress), ttl: nil)
+            return ARecord(address: .init(address: parsedAddress), ttl: nil)
         }
 
         func generateReply(records: [ARecord]) throws -> [ARecord] {
@@ -250,7 +250,7 @@ extension DNSSD {
             var parsedAddressBytes = [CChar](repeating: 0, count: Int(INET6_ADDRSTRLEN))
             inet_ntop(AF_INET6, ptr, &parsedAddressBytes, socklen_t(INET6_ADDRSTRLEN))
             let parsedAddress = String(cString: parsedAddressBytes)
-            return AAAARecord(address: .IPv6(parsedAddress), ttl: nil)
+            return AAAARecord(address: .init(address: parsedAddress), ttl: nil)
         }
 
         func generateReply(records: [AAAARecord]) throws -> [AAAARecord] {

--- a/Tests/AsyncDNSResolverTests/dnssd/DNSSDDNSResolverTests.swift
+++ b/Tests/AsyncDNSResolverTests/dnssd/DNSSDDNSResolverTests.swift
@@ -108,7 +108,7 @@ final class DNSSDDNSResolverTests: XCTestCase {
         let addrBytes: [UInt8] = [38, 32, 1, 73]
         try addrBytes.withUnsafeBufferPointer {
             let record = try DNSSD.AQueryReplyHandler.instance.parseRecord(data: $0.baseAddress, length: UInt16($0.count))
-            XCTAssertEqual(record, ARecord(address: .IPv4("38.32.1.73"), ttl: nil))
+            XCTAssertEqual(record, ARecord(address: .init(address: "38.32.1.73"), ttl: nil))
         }
     }
 


### PR DESCRIPTION
Motivation:

The `ARecord` and `AAAARecord` use the `IPAddress` `enum` as their address types. However, they should only use IPv4 and IPv6 addresses respectively.

Modifications:

- Add `IPAddress.IPv4` and IPAddress.IPv6` types and use them as the associated values in the `IPAddress` enum
- Change the casing of the `IPAddress` cases from `.IPv4` and `.IPv6` to `.ipv4` and `.ipv6` as Swift case names are usually lower-camel case

Result:

- The types of IP address used by `ARecord` and `AAAARecord` are clearer.
- It's not possible to create an `ARecord` with an IPv6 address