### PR TITLE
Move platform availability to types

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,10 +21,6 @@ do {
 
 let package = Package(
     name: "swift-async-dns-resolver",
-    platforms: [
-        .macOS("13.0"),
-        .iOS(.v13),
-    ],
     products: [
         .library(name: "AsyncDNSResolver", targets: ["AsyncDNSResolver"]),
     ],

--- a/Sources/AsyncDNSResolver/AsyncDNSResolver.swift
+++ b/Sources/AsyncDNSResolver/AsyncDNSResolver.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftAsyncDNSResolver open source project
 //
-// Copyright (c) 2020-2023 Apple Inc. and the SwiftAsyncDNSResolver project authors
+// Copyright (c) 2020-2024 Apple Inc. and the SwiftAsyncDNSResolver project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -15,6 +15,7 @@
 // MARK: - Async DNS resolver API
 
 /// `AsyncDNSResolver` provides API for running asynchronous DNS queries.
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public struct AsyncDNSResolver {
     let underlying: DNSResolver
 

--- a/Sources/AsyncDNSResolver/Errors.swift
+++ b/Sources/AsyncDNSResolver/Errors.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftAsyncDNSResolver open source project
 //
-// Copyright (c) 2020-2023 Apple Inc. and the SwiftAsyncDNSResolver project authors
+// Copyright (c) 2020-2024 Apple Inc. and the SwiftAsyncDNSResolver project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension AsyncDNSResolver {
     /// Possible ``AsyncDNSResolver/AsyncDNSResolver`` errors.
     public struct Error: Swift.Error, CustomStringConvertible {

--- a/Sources/AsyncDNSResolver/c-ares/AresChannel.swift
+++ b/Sources/AsyncDNSResolver/c-ares/AresChannel.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftAsyncDNSResolver open source project
 //
-// Copyright (c) 2020-2023 Apple Inc. and the SwiftAsyncDNSResolver project authors
+// Copyright (c) 2020-2024 Apple Inc. and the SwiftAsyncDNSResolver project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -17,6 +17,7 @@ import Foundation
 
 // MARK: - ares_channel
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 class AresChannel {
     let pointer: UnsafeMutablePointer<ares_channel?>
     let lock = NSLock()
@@ -62,6 +63,7 @@ class AresChannel {
     }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 private func checkAresResult(body: () -> Int32) throws {
     let result = body()
     guard result == ARES_SUCCESS else {

--- a/Sources/AsyncDNSResolver/c-ares/AresOptions.swift
+++ b/Sources/AsyncDNSResolver/c-ares/AresOptions.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftAsyncDNSResolver open source project
 //
-// Copyright (c) 2020-2023 Apple Inc. and the SwiftAsyncDNSResolver project authors
+// Copyright (c) 2020-2024 Apple Inc. and the SwiftAsyncDNSResolver project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -16,6 +16,7 @@ import CAsyncDNSResolver
 
 // MARK: - Options for `CAresDNSResolver`
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension CAresDNSResolver {
     /// Options for ``CAresDNSResolver``.
     public struct Options {
@@ -88,6 +89,7 @@ extension CAresDNSResolver {
     }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension CAresDNSResolver.Options {
     public struct Flags: OptionSet {
         public let rawValue: Int32
@@ -120,6 +122,7 @@ extension CAresDNSResolver.Options {
     }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension CAresDNSResolver.Options {
     var aresOptions: AresOptions {
         let aresOptions = AresOptions()

--- a/Sources/AsyncDNSResolver/c-ares/DNSResolver_c-ares.swift
+++ b/Sources/AsyncDNSResolver/c-ares/DNSResolver_c-ares.swift
@@ -15,6 +15,7 @@
 import CAsyncDNSResolver
 
 /// ``DNSResolver`` implementation backed by c-ares C library.
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public class CAresDNSResolver: DNSResolver {
     let options: Options
     let ares: Ares
@@ -119,6 +120,7 @@ extension QueryType {
 
 // MARK: - c-ares query wrapper
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 class Ares {
     typealias QueryCallback = @convention(c) (UnsafeMutableRawPointer?, CInt, CInt, UnsafeMutablePointer<CUnsignedChar>?, CInt) -> Void
 
@@ -183,6 +185,7 @@ class Ares {
     }
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension Ares {
     // TODO: implement this more nicely using NIO EventLoop?
     // See:
@@ -253,6 +256,7 @@ extension Ares {
 
 // MARK: - c-ares query reply handler
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension Ares {
     struct QueryReplyHandler {
         private let _handler: (CInt, UnsafeMutablePointer<CUnsignedChar>?, CInt) -> Void
@@ -291,6 +295,7 @@ protocol AresQueryReplyParser {
     func parse(buffer: UnsafeMutablePointer<CUnsignedChar>?, length: CInt) throws -> Reply
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension Ares {
     static let maxAddresses: Int = 32
 

--- a/Sources/AsyncDNSResolver/c-ares/Errors_c-ares.swift
+++ b/Sources/AsyncDNSResolver/c-ares/Errors_c-ares.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftAsyncDNSResolver open source project
 //
-// Copyright (c) 2020-2023 Apple Inc. and the SwiftAsyncDNSResolver project authors
+// Copyright (c) 2020-2024 Apple Inc. and the SwiftAsyncDNSResolver project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -14,6 +14,7 @@
 
 import CAsyncDNSResolver
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension AsyncDNSResolver.Error {
     /// Create an ``AsyncDNSResolver/AsyncDNSResolver/Error`` from c-ares error code.
     init(code: Int32, _ description: String? = nil) {

--- a/Sources/AsyncDNSResolver/dnssd/DNSResolver_dnssd.swift
+++ b/Sources/AsyncDNSResolver/dnssd/DNSResolver_dnssd.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftAsyncDNSResolver open source project
 //
-// Copyright (c) 2023 Apple Inc. and the SwiftAsyncDNSResolver project authors
+// Copyright (c) 2023-2024 Apple Inc. and the SwiftAsyncDNSResolver project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -16,6 +16,7 @@
 import dnssd
 
 /// ``DNSResolver`` implementation backed by dnssd framework.
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public struct DNSSDDNSResolver: DNSResolver {
     let dnssd: DNSSD
 
@@ -98,6 +99,7 @@ extension QueryType {
 
 // MARK: - dnssd query wrapper
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 struct DNSSD {
     // Reference: https://gist.github.com/fikeminkel/a9c4bc4d0348527e8df3690e242038d3
     func query<ReplyHandler: DNSSDQueryReplyHandler>(
@@ -167,6 +169,7 @@ struct DNSSD {
 
 // MARK: - dnssd query reply handler
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension DNSSD {
     struct QueryReplyHandler {
         private let _handleRecord: (DNSServiceErrorType, UnsafeRawPointer?, UInt16) -> Void
@@ -208,6 +211,7 @@ protocol DNSSDQueryReplyHandler {
     func generateReply(records: [Record]) throws -> Reply
 }
 
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension DNSSD {
     // Reference: https://github.com/orlandos-nl/DNSClient/blob/master/Sources/DNSClient/Messages/Message.swift
 
@@ -450,6 +454,7 @@ extension DNSSDQueryReplyHandler {
         return parts.isEmpty ? nil : parts.joined(separator: ".")
     }
 
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     func ensureOne<R>(records: [R]) throws -> R {
         guard records.count <= 1 else {
             throw AsyncDNSResolver.Error.badResponse("expected 1 record but got \(records.count)")

--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -18,7 +18,7 @@ here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function replace_acceptable_years() {
     # this needs to replace all acceptable forms with 'YEARS'
-    sed -e 's/202[012]-202[1234]/YEARS/' -e 's/202[01234]/YEARS/'
+    sed -e 's/202[0123]-202[1234]/YEARS/' -e 's/202[01234]/YEARS/'
 }
 
 if ! hash swiftformat &> /dev/null


### PR DESCRIPTION
Motivation:
Having `platforms` in `Package.swift` might prevent others from adopting this library.

Modifications:
- Move platform availability to types
- Remove `platforms` in `Package.swift`
- macOS 10.15 seems to be sufficient, so lowering requirement from v13.0
