### PR TITLE
Add public inits to record types

### DIFF
--- a/Sources/AsyncDNSResolver/AsyncDNSResolver.swift
+++ b/Sources/AsyncDNSResolver/AsyncDNSResolver.swift
@@ -184,7 +184,7 @@ enum QueryType {
 
 // MARK: - Query reply types
 
-public enum IPAddress: Sendable, Equatable, CustomStringConvertible {
+public enum IPAddress: Sendable, Hashable, CustomStringConvertible {
     case ipv4(IPv4)
     case ipv6(IPv6)
 
@@ -216,33 +216,47 @@ public enum IPAddress: Sendable, Equatable, CustomStringConvertible {
     }
 }
 
-public struct ARecord: Sendable, Equatable, CustomStringConvertible {
+public struct ARecord: Sendable, Hashable, CustomStringConvertible {
     public let address: IPAddress.IPv4
     public let ttl: Int32?
 
     public var description: String {
         "\(Self.self)(address=\(self.address), ttl=\(self.ttl.map { "\($0)" } ?? ""))"
     }
+
+    public init(address: IPAddress.IPv4, ttl: Int32?) {
+        self.address = address
+        self.ttl = ttl
+    }
 }
 
-public struct AAAARecord: Sendable, Equatable, CustomStringConvertible {
+public struct AAAARecord: Sendable, Hashable, CustomStringConvertible {
     public let address: IPAddress.IPv6
     public let ttl: Int32?
 
     public var description: String {
         "\(Self.self)(address=\(self.address), ttl=\(self.ttl.map { "\($0)" } ?? ""))"
     }
+
+    public init(address: IPAddress.IPv6, ttl: Int32?) {
+        self.address = address
+        self.ttl = ttl
+    }
 }
 
-public struct NSRecord: Sendable, Equatable, CustomStringConvertible {
+public struct NSRecord: Sendable, Hashable, CustomStringConvertible {
     public let nameservers: [String]
 
     public var description: String {
         "\(Self.self)(nameservers=\(self.nameservers))"
     }
+
+    public init(nameservers: [String]) {
+        self.nameservers = nameservers
+    }
 }
 
-public struct SOARecord: Sendable, Equatable, CustomStringConvertible {
+public struct SOARecord: Sendable, Hashable, CustomStringConvertible {
     public let mname: String?
     public let rname: String?
     public let serial: UInt32
@@ -256,32 +270,45 @@ public struct SOARecord: Sendable, Equatable, CustomStringConvertible {
     }
 }
 
-public struct PTRRecord: Sendable, Equatable, CustomStringConvertible {
+public struct PTRRecord: Sendable, Hashable, CustomStringConvertible {
     public let names: [String]
 
     public var description: String {
         "\(Self.self)(names=\(self.names))"
     }
+
+    public init(names: [String]) {
+        self.names = names
+    }
 }
 
-public struct MXRecord: Sendable, Equatable, CustomStringConvertible {
+public struct MXRecord: Sendable, Hashable, CustomStringConvertible {
     public let host: String
     public let priority: UInt16
 
     public var description: String {
         "\(Self.self)(host=\(self.host), priority=\(self.priority))"
     }
+
+    public init(host: String, priority: UInt16) {
+        self.host = host
+        self.priority = priority
+    }
 }
 
-public struct TXTRecord: Sendable, Equatable {
+public struct TXTRecord: Sendable, Hashable {
     public let txt: String
 
     public var description: String {
         "\(Self.self)(\(self.txt))"
     }
+
+    public init(txt: String) {
+        self.txt = txt
+    }
 }
 
-public struct SRVRecord: Sendable, Equatable, CustomStringConvertible {
+public struct SRVRecord: Sendable, Hashable, CustomStringConvertible {
     public let host: String
     public let port: UInt16
     public let weight: UInt16
@@ -290,9 +317,16 @@ public struct SRVRecord: Sendable, Equatable, CustomStringConvertible {
     public var description: String {
         "\(Self.self)(host=\(self.host), port=\(self.port), weight=\(self.weight), priority=\(self.priority))"
     }
+
+    public init(host: String, port: UInt16, weight: UInt16, priority: UInt16) {
+        self.host = host
+        self.port = port
+        self.weight = weight
+        self.priority = priority
+    }
 }
 
-public struct NAPTRRecord: Sendable, Equatable, CustomStringConvertible {
+public struct NAPTRRecord: Sendable, Hashable, CustomStringConvertible {
     public let flags: String?
     public let service: String?
     public let regExp: String?
@@ -302,5 +336,14 @@ public struct NAPTRRecord: Sendable, Equatable, CustomStringConvertible {
 
     public var description: String {
         "\(Self.self)(flags=\(self.flags ?? ""), service=\(self.service ?? ""), regExp=\(self.regExp ?? ""), replacement=\(self.replacement), order=\(self.order), preference=\(self.preference))"
+    }
+
+    public init(flags: String?, service: String?, regExp: String?, replacement: String, order: UInt16, preference: UInt16) {
+        self.flags = flags
+        self.service = service
+        self.regExp = regExp
+        self.replacement = replacement
+        self.order = order
+        self.preference = preference
     }
 }


### PR DESCRIPTION
Motivation:

The record types are public but don't have public inits, this makes it impossible for users to implement the `DNSResolver` protocol in a useful way.

The record types are also `Equatable` but not `Hashable`. There's no reason for them not to be `Hashable`.

Modifications:

- Add `public` `init`s to the record types
- Make the record types `Hashable`

Result:

Possible to implement a `DNSResolver`