### PR TITLE
Add missing platform availability annotation

### DIFF
--- a/Sources/AsyncDNSResolver/AsyncDNSResolver.swift
+++ b/Sources/AsyncDNSResolver/AsyncDNSResolver.swift
@@ -95,6 +95,7 @@ public struct AsyncDNSResolver {
 }
 
 /// API for running DNS queries.
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public protocol DNSResolver {
     /// Lookup A records associated with `name`.
     ///


### PR DESCRIPTION
It's missing for `DNSResolver` and results in build failing in iOS.

Resolves https://github.com/apple/swift-async-dns-resolver/issues/25

