### PR TITLE
Simplify AsyncDNSResolver.Error 

### DIFF
--- a/Sources/AsyncDNSResolver/Errors.swift
+++ b/Sources/AsyncDNSResolver/Errors.swift
@@ -15,33 +15,14 @@
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension AsyncDNSResolver {
     /// Possible ``AsyncDNSResolver/AsyncDNSResolver`` errors.
-    public struct Error: Swift.Error, Hashable, CustomStringConvertible {
+    public struct Error: Swift.Error, CustomStringConvertible {
         public struct Code: Hashable, Sendable {
             fileprivate enum Value: Hashable, Sendable {
-                case invalidQuery
-                case serverFailure
-                case notFound
-                case notImplemented
-                case serverRefused
                 case badQuery
-                case badName
-                case badFamily
                 case badResponse
                 case connectionRefused
                 case timeout
-                case eof
-                case fileIO
-                case noMemory
-                case destruction
-                case badString
-                case badFlags
-                case noName
-                case badHints
-                case notInitialized
-                case initError
-                case cancelled
-                case service
-                case other(Int)
+                case internalError
             }
 
             fileprivate var value: Value
@@ -49,116 +30,69 @@ extension AsyncDNSResolver {
                 self.value = value
             }
 
-            public static var invalidQuery: Self { Self(.invalidQuery) }
-
-            public static var serverFailure: Self { Self(.serverFailure) }
-
-            public static var notFound: Self { Self(.notFound) }
-
-            public static var notImplemented: Self { Self(.notImplemented) }
-
-            public static var serverRefused: Self { Self(.serverRefused) }
-
+            /// The query was badly formed.
             public static var badQuery: Self { Self(.badQuery) }
 
-            public static var badName: Self { Self(.badName) }
-
-            public static var badFamily: Self { Self(.badFamily) }
-
+            /// The response couldn't be parsed.
             public static var badResponse: Self { Self(.badResponse) }
 
+            /// The server refused to accept a connection.
             public static var connectionRefused: Self { Self(.connectionRefused) }
 
+            /// The query timed out.
             public static var timeout: Self { Self(.timeout) }
 
-            public static var eof: Self { Self(.eof) }
-
-            public static var fileIO: Self { Self(.fileIO) }
-
-            public static var noMemory: Self { Self(.noMemory) }
-
-            public static var destruction: Self { Self(.destruction) }
-
-            public static var badString: Self { Self(.badString) }
-
-            public static var badFlags: Self { Self(.badFlags) }
-
-            public static var noName: Self { Self(.noName) }
-
-            public static var badHints: Self { Self(.badHints) }
-
-            public static var notInitialized: Self { Self(.notInitialized) }
-
-            public static var initError: Self { Self(.initError) }
-
-            public static var cancelled: Self { Self(.cancelled) }
-
-            public static var service: Self { Self(.service) }
-
-            public static func other(_ code: Int) -> Self {
-                Self(.other(code))
-            }
+            /// An internal error.
+            public static var internalError: Self { Self(.internalError) }
         }
 
         public var code: Code
         public var message: String
+        public var source: Swift.Error?
 
-        public init(code: Code, message: String = "") {
+        public init(code: Code, message: String = "", source: Swift.Error? = nil) {
             self.code = code
             self.message = message
+            self.source = source
         }
 
         public var description: String {
+            let name: String
             switch self.code.value {
-            case .invalidQuery:
-                return "invalid query: \(self.message)"
-            case .serverFailure:
-                return "server failure: \(self.message)"
-            case .notFound:
-                return "not found: \(self.message)"
-            case .notImplemented:
-                return "not implemented: \(self.message)"
-            case .serverRefused:
-                return "server refused: \(self.message)"
             case .badQuery:
-                return "bad query: \(self.message)"
-            case .badName:
-                return "bad name: \(self.message)"
-            case .badFamily:
-                return "bad family: \(self.message)"
+                name = "bad query"
             case .badResponse:
-                return "bad response: \(self.message)"
+                name = "bad response"
             case .connectionRefused:
-                return "connection refused: \(self.message)"
+                name = "connection refused"
             case .timeout:
-                return "timeout: \(self.message)"
-            case .eof:
-                return "EOF: \(self.message)"
-            case .fileIO:
-                return "file IO: \(self.message)"
-            case .noMemory:
-                return "no memory: \(self.message)"
-            case .destruction:
-                return "destruction: \(self.message)"
-            case .badString:
-                return "bad string: \(self.message)"
-            case .badFlags:
-                return "bad flags: \(self.message)"
-            case .noName:
-                return "no name: \(self.message)"
-            case .badHints:
-                return "bad hints: \(self.message)"
-            case .notInitialized:
-                return "not initialized: \(self.message)"
-            case .initError:
-                return "initialization error: \(self.message)"
-            case .cancelled:
-                return "cancelled: \(self.message)"
-            case .service:
-                return "service: \(self.message)"
-            case .other(let code):
-                return "other [\(code)]: \(self.message)"
+                name = "timeout"
+            case .internalError:
+                name = "internal"
             }
+
+            let suffix = self.source.map { " (\($0))" } ?? ""
+            return "\(name): \(self.message)\(suffix)"
         }
+    }
+}
+
+/// An error thrown from c-ares.
+public struct CAresError: Error, Hashable, Sendable {
+    /// The error code.
+    public var code: Int
+
+    public init(code: Int) {
+        self.code = code
+    }
+}
+
+/// An error thrown from DNSSD.
+public struct DNSSDError: Error, Hashable, Sendable {
+    /// The error code.
+    public var code: Int
+
+    public init(code: Int) {
+        self.code = code
     }
 }

--- a/Sources/AsyncDNSResolver/c-ares/AresChannel.swift
+++ b/Sources/AsyncDNSResolver/c-ares/AresChannel.swift
@@ -67,6 +67,6 @@ class AresChannel {
 private func checkAresResult(body: () -> Int32) throws {
     let result = body()
     guard result == ARES_SUCCESS else {
-        throw AsyncDNSResolver.Error(code: result, "failed to initialize channel")
+        throw AsyncDNSResolver.Error(cAresCode: result, "failed to initialize channel")
     }
 }

--- a/Sources/AsyncDNSResolver/c-ares/DNSResolver_c-ares.swift
+++ b/Sources/AsyncDNSResolver/c-ares/DNSResolver_c-ares.swift
@@ -268,7 +268,7 @@ extension Ares {
         init<Parser: AresQueryReplyParser>(parser: Parser, _ continuation: CheckedContinuation<Parser.Reply, Error>) {
             self._handler = { status, buffer, length in
                 guard status == ARES_SUCCESS || status == ARES_ENODATA else {
-                    return continuation.resume(throwing: AsyncDNSResolver.Error(code: status))
+                    return continuation.resume(throwing: AsyncDNSResolver.Error(cAresCode: status))
                 }
 
                 do {
@@ -322,7 +322,7 @@ extension Ares {
                 return []
 
             default:
-                throw AsyncDNSResolver.Error(code: parseStatus, "failed to parse A query reply")
+                throw AsyncDNSResolver.Error(cAresCode: parseStatus, "failed to parse A query reply")
             }
         }
     }
@@ -351,7 +351,7 @@ extension Ares {
                 return []
 
             default:
-                throw AsyncDNSResolver.Error(code: parseStatus, "failed to parse AAAA query reply")
+                throw AsyncDNSResolver.Error(cAresCode: parseStatus, "failed to parse AAAA query reply")
             }
         }
     }
@@ -378,7 +378,7 @@ extension Ares {
                 return NSRecord(nameservers: [])
 
             default:
-                throw AsyncDNSResolver.Error(code: parseStatus, "failed to parse NS query reply")
+                throw AsyncDNSResolver.Error(cAresCode: parseStatus, "failed to parse NS query reply")
             }
         }
     }
@@ -402,7 +402,7 @@ extension Ares {
             case ARES_ENODATA:
                 return nil
             default:
-                throw AsyncDNSResolver.Error(code: parseStatus, "failed to parse CNAME query reply")
+                throw AsyncDNSResolver.Error(cAresCode: parseStatus, "failed to parse CNAME query reply")
             }
         }
     }
@@ -435,7 +435,7 @@ extension Ares {
                 return nil
 
             default:
-                throw AsyncDNSResolver.Error(code: parseStatus, "failed to parse SOA query reply")
+                throw AsyncDNSResolver.Error(cAresCode: parseStatus, "failed to parse SOA query reply")
             }
         }
     }
@@ -464,7 +464,7 @@ extension Ares {
                 return PTRRecord(names: [])
 
             default:
-                throw AsyncDNSResolver.Error(code: parseStatus, "failed to parse PTR query record")
+                throw AsyncDNSResolver.Error(cAresCode: parseStatus, "failed to parse PTR query record")
             }
         }
     }
@@ -496,7 +496,7 @@ extension Ares {
                 return []
 
             default:
-                throw AsyncDNSResolver.Error(code: parseStatus, "failed to parse MX query record")
+                throw AsyncDNSResolver.Error(cAresCode: parseStatus, "failed to parse MX query record")
             }
         }
     }
@@ -528,7 +528,7 @@ extension Ares {
                 return []
 
             default:
-                throw AsyncDNSResolver.Error(code: parseStatus, "failed to parse TXT query reply")
+                throw AsyncDNSResolver.Error(cAresCode: parseStatus, "failed to parse TXT query reply")
             }
         }
     }
@@ -563,7 +563,7 @@ extension Ares {
                 return []
 
             default:
-                throw AsyncDNSResolver.Error(code: parseStatus, "failed to parse SRV query reply")
+                throw AsyncDNSResolver.Error(cAresCode: parseStatus, "failed to parse SRV query reply")
             }
         }
     }
@@ -600,7 +600,7 @@ extension Ares {
                 return []
 
             default:
-                throw AsyncDNSResolver.Error(code: parseStatus, "failed to parse NAPTR query reply")
+                throw AsyncDNSResolver.Error(cAresCode: parseStatus, "failed to parse NAPTR query reply")
             }
         }
     }

--- a/Sources/AsyncDNSResolver/dnssd/DNSResolver_dnssd.swift
+++ b/Sources/AsyncDNSResolver/dnssd/DNSResolver_dnssd.swift
@@ -155,7 +155,7 @@ struct DNSSD {
 
             // Check if query completed successfully
             guard _code == kDNSServiceErr_NoError else {
-                return continuation.finish(throwing: AsyncDNSResolver.Error(code: .other(Int(_code))))
+                return continuation.finish(throwing: AsyncDNSResolver.Error(dnssdCode: _code))
             }
 
             // Read reply from the socket (blocking) then call reply handler
@@ -198,7 +198,7 @@ extension DNSSD {
                     data = nil
                     length = 0
                 default:
-                    return continuation.finish(throwing: AsyncDNSResolver.Error(code: .other(Int(errorCode))))
+                    return continuation.finish(throwing: AsyncDNSResolver.Error(dnssdCode: errorCode))
                 }
 
                 do {

--- a/Sources/AsyncDNSResolver/dnssd/Errors_dnssd.swift
+++ b/Sources/AsyncDNSResolver/dnssd/Errors_dnssd.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftAsyncDNSResolver open source project
 //
-// Copyright (c) 2020-2024 Apple Inc. and the SwiftAsyncDNSResolver project authors
+// Copyright (c) 2024 Apple Inc. and the SwiftAsyncDNSResolver project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -12,26 +12,27 @@
 //
 //===----------------------------------------------------------------------===//
 
-import CAsyncDNSResolver
+#if canImport(Darwin)
+import dnssd
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension AsyncDNSResolver.Error {
-    /// Create an ``AsyncDNSResolver/AsyncDNSResolver/Error`` from c-ares error code.
-    init(cAresCode: Int32, _ description: String = "") {
+    /// Create an ``AsyncDNSResolver/AsyncDNSResolver/Error`` from a DNSSD error code.
+    init(dnssdCode code: Int32, _ description: String = "") {
         self.message = description
-        self.source = CAresError(code: Int(cAresCode))
+        self.source = DNSSDError(code: Int(code))
 
-        switch cAresCode {
-        case ARES_EFORMERR, ARES_EBADQUERY, ARES_EBADNAME, ARES_EBADFAMILY, ARES_EBADFLAGS:
+        switch Int(code) {
+        case kDNSServiceErr_BadFlags, kDNSServiceErr_BadParam, kDNSServiceErr_Invalid:
             self.code = .badQuery
-        case ARES_EBADRESP:
-            self.code = .badResponse
-        case ARES_ECONNREFUSED:
+        case kDNSServiceErr_Refused:
             self.code = .connectionRefused
-        case ARES_ETIMEOUT:
+        case kDNSServiceErr_Timeout:
             self.code = .timeout
         default:
             self.code = .internalError
         }
     }
 }
+
+#endif

--- a/Tests/AsyncDNSResolverTests/c-ares/AresErrorTests.swift
+++ b/Tests/AsyncDNSResolverTests/c-ares/AresErrorTests.swift
@@ -26,7 +26,7 @@ final class AresErrorTests: XCTestCase {
             ARES_EBADFLAGS: .badQuery,
             ARES_EBADRESP: .badResponse,
             ARES_ECONNREFUSED: .connectionRefused,
-            ARES_ETIMEOUT: .timeout
+            ARES_ETIMEOUT: .timeout,
         ]
 
         for (code, expected) in inputs {

--- a/Tests/AsyncDNSResolverTests/dnssd/DNSSDDNSResolverTests.swift
+++ b/Tests/AsyncDNSResolverTests/dnssd/DNSSDDNSResolverTests.swift
@@ -173,14 +173,14 @@ final class DNSSDDNSResolverTests: XCTestCase {
         try await run { i in
             let reply = try await self.resolver.queryCNAME(name: "www.apple.com")
             if self.verbose {
-                print("[CNAME] run #\(i) result: \(reply)")
+                print("[CNAME] run #\(i) result: \(String(describing: reply))")
             }
         }
 
         try await run { i in
             let reply = try await self.resolver.querySOA(name: "apple.com")
             if self.verbose {
-                print("[SOA] run #\(i) result: \(reply)")
+                print("[SOA] run #\(i) result: \(String(describing: reply))")
             }
         }
 

--- a/Tests/AsyncDNSResolverTests/dnssd/DNSSDErrorTests.swift
+++ b/Tests/AsyncDNSResolverTests/dnssd/DNSSDErrorTests.swift
@@ -13,8 +13,8 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(Darwin)
-import dnssd
 @testable import AsyncDNSResolver
+import dnssd
 import XCTest
 
 final class DNSSDErrorTests: XCTestCase {

--- a/Tests/AsyncDNSResolverTests/dnssd/DNSSDErrorTests.swift
+++ b/Tests/AsyncDNSResolverTests/dnssd/DNSSDErrorTests.swift
@@ -24,7 +24,7 @@ final class DNSSDErrorTests: XCTestCase {
             kDNSServiceErr_BadParam: .badQuery,
             kDNSServiceErr_Invalid: .badQuery,
             kDNSServiceErr_Refused: .connectionRefused,
-            kDNSServiceErr_Timeout: .timeout
+            kDNSServiceErr_Timeout: .timeout,
         ]
 
         for (code, expected) in inputs {

--- a/Tests/AsyncDNSResolverTests/dnssd/DNSSDErrorTests.swift
+++ b/Tests/AsyncDNSResolverTests/dnssd/DNSSDErrorTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftAsyncDNSResolver open source project
 //
-// Copyright (c) 2020 Apple Inc. and the SwiftAsyncDNSResolver project authors
+// Copyright (c) 2024 Apple Inc. and the SwiftAsyncDNSResolver project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -12,27 +12,26 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(Darwin)
+import dnssd
 @testable import AsyncDNSResolver
-import CAsyncDNSResolver
 import XCTest
 
-final class AresErrorTests: XCTestCase {
+final class DNSSDErrorTests: XCTestCase {
     func test_initFromCode() {
-        let inputs: [Int32: AsyncDNSResolver.Error.Code] = [
-            ARES_EFORMERR: .badQuery,
-            ARES_EBADQUERY: .badQuery,
-            ARES_EBADNAME: .badQuery,
-            ARES_EBADFAMILY: .badQuery,
-            ARES_EBADFLAGS: .badQuery,
-            ARES_EBADRESP: .badResponse,
-            ARES_ECONNREFUSED: .connectionRefused,
-            ARES_ETIMEOUT: .timeout
+        let inputs: [Int: AsyncDNSResolver.Error.Code] = [
+            kDNSServiceErr_BadFlags: .badQuery,
+            kDNSServiceErr_BadParam: .badQuery,
+            kDNSServiceErr_Invalid: .badQuery,
+            kDNSServiceErr_Refused: .connectionRefused,
+            kDNSServiceErr_Timeout: .timeout
         ]
 
         for (code, expected) in inputs {
-            let error = AsyncDNSResolver.Error(cAresCode: code, "some error")
+            let error = AsyncDNSResolver.Error(dnssdCode: Int32(code), "some error")
             XCTAssertEqual(error.code, expected)
             XCTAssertEqual(error.message, "some error", "Expected description to be \"some error\", got \(error.message)")
         }
     }
 }
+#endif


### PR DESCRIPTION
Motivation:

The 'AsyncDNSResolver.Error' is closely modelled on the c-ares error
codes and doesn't fit well with the DNSSD error codes. Further, the
DNSSD backed doesn't map its error cdes back into an
'AsyncDNSResolver.Error' so all DNSSD errors become 'other' errors.

Modifications:

- Reduce the number of error codes in 'AsyncDNSResolver.Error' to a few
  high level error codes and a catch-all 'internal' error code.
- Update mappings from c-ares error codes, add mappings from dnssd error
  codes.
- Add a 'source' property, which can be 'any Error', allowing users to
  get fine grained error information if necessary.

Result:

Error codes are more consistent across implementations.