### PR TITLE
Don't throw on empty responses

### DIFF
--- a/Sources/AsyncDNSResolver/AsyncDNSResolver.swift
+++ b/Sources/AsyncDNSResolver/AsyncDNSResolver.swift
@@ -142,7 +142,7 @@ public protocol DNSResolver {
     /// - Parameters:
     ///   - name: The name to resolve.
     ///
-    /// - Returns: ``PTRRecord`` for the given name, `nil` if no record was found.
+    /// - Returns: ``PTRRecord`` for the given name.
     func queryPTR(name: String) async throws -> PTRRecord
 
     /// Lookup MX records associated with `name`.

--- a/Sources/AsyncDNSResolver/AsyncDNSResolver.swift
+++ b/Sources/AsyncDNSResolver/AsyncDNSResolver.swift
@@ -64,12 +64,12 @@ public struct AsyncDNSResolver {
     }
 
     /// See ``DNSResolver/queryCNAME(name:)``.
-    public func queryCNAME(name: String) async throws -> String {
+    public func queryCNAME(name: String) async throws -> String? {
         try await self.underlying.queryCNAME(name: name)
     }
 
     /// See ``DNSResolver/querySOA(name:)``.
-    public func querySOA(name: String) async throws -> SOARecord {
+    public func querySOA(name: String) async throws -> SOARecord? {
         try await self.underlying.querySOA(name: name)
     }
 
@@ -102,7 +102,7 @@ public protocol DNSResolver {
     /// - Parameters:
     ///   - name: The name to resolve.
     ///
-    /// - Returns: ``ARecord``s for the given name.
+    /// - Returns: ``ARecord``s for the given name, empty if no records were found.
     func queryA(name: String) async throws -> [ARecord]
 
     /// Lookup AAAA records associated with `name`.
@@ -110,7 +110,7 @@ public protocol DNSResolver {
     /// - Parameters:
     ///   - name: The name to resolve.
     ///
-    /// - Returns: ``AAAARecord``s for the given name.
+    /// - Returns: ``AAAARecord``s for the given name, empty if no records were found.
     func queryAAAA(name: String) async throws -> [AAAARecord]
 
     /// Lookup NS record associated with `name`.
@@ -126,23 +126,23 @@ public protocol DNSResolver {
     /// - Parameters:
     ///   - name: The name to resolve.
     ///
-    /// - Returns: CNAME for the given name.
-    func queryCNAME(name: String) async throws -> String
+    /// - Returns: CNAME for the given name, `nil` if no record was found.
+    func queryCNAME(name: String) async throws -> String?
 
     /// Lookup SOA record associated with `name`.
     ///
     /// - Parameters:
     ///   - name: The name to resolve.
     ///
-    /// - Returns: ``SOARecord`` for the given name.
-    func querySOA(name: String) async throws -> SOARecord
+    /// - Returns: ``SOARecord`` for the given name, `nil` if no record was found.
+    func querySOA(name: String) async throws -> SOARecord?
 
     /// Lookup PTR record associated with `name`.
     ///
     /// - Parameters:
     ///   - name: The name to resolve.
     ///
-    /// - Returns: ``PTRRecord`` for the given name.
+    /// - Returns: ``PTRRecord`` for the given name, `nil` if no record was found.
     func queryPTR(name: String) async throws -> PTRRecord
 
     /// Lookup MX records associated with `name`.
@@ -150,7 +150,7 @@ public protocol DNSResolver {
     /// - Parameters:
     ///   - name: The name to resolve.
     ///
-    /// - Returns: ``MXRecord``s for the given name.
+    /// - Returns: ``MXRecord``s for the given name, empty if no records were found.
     func queryMX(name: String) async throws -> [MXRecord]
 
     /// Lookup TXT records associated with `name`.
@@ -158,7 +158,7 @@ public protocol DNSResolver {
     /// - Parameters:
     ///   - name: The name to resolve.
     ///
-    /// - Returns: ``TXTRecord``s for the given name.
+    /// - Returns: ``TXTRecord``s for the given name, empty if no records were found.
     func queryTXT(name: String) async throws -> [TXTRecord]
 
     /// Lookup SRV records associated with `name`.
@@ -166,7 +166,7 @@ public protocol DNSResolver {
     /// - Parameters:
     ///   - name: The name to resolve.
     ///
-    /// - Returns: ``SRVRecord``s for the given name.
+    /// - Returns: ``SRVRecord``s for the given name, empty if no records were found.
     func querySRV(name: String) async throws -> [SRVRecord]
 }
 

--- a/Sources/AsyncDNSResolver/Errors.swift
+++ b/Sources/AsyncDNSResolver/Errors.swift
@@ -18,7 +18,6 @@ extension AsyncDNSResolver {
     public struct Error: Swift.Error, Hashable, CustomStringConvertible {
         public struct Code: Hashable, Sendable {
             fileprivate enum Value: Hashable, Sendable {
-                case noData
                 case invalidQuery
                 case serverFailure
                 case notFound
@@ -49,8 +48,6 @@ extension AsyncDNSResolver {
             private init(_ value: Value) {
                 self.value = value
             }
-
-            public static var noData: Self { Self(.noData) }
 
             public static var invalidQuery: Self { Self(.invalidQuery) }
 
@@ -113,8 +110,6 @@ extension AsyncDNSResolver {
 
         public var description: String {
             switch self.code.value {
-            case .noData:
-                return "no data: \(self.message)"
             case .invalidQuery:
                 return "invalid query: \(self.message)"
             case .serverFailure:

--- a/Sources/AsyncDNSResolver/c-ares/DNSResolver_c-ares.swift
+++ b/Sources/AsyncDNSResolver/c-ares/DNSResolver_c-ares.swift
@@ -437,7 +437,6 @@ extension Ares {
             default:
                 throw AsyncDNSResolver.Error(code: parseStatus, "failed to parse SOA query reply")
             }
-
         }
     }
 
@@ -603,7 +602,6 @@ extension Ares {
             default:
                 throw AsyncDNSResolver.Error(code: parseStatus, "failed to parse NAPTR query reply")
             }
-
         }
     }
 }

--- a/Sources/AsyncDNSResolver/c-ares/DNSResolver_c-ares.swift
+++ b/Sources/AsyncDNSResolver/c-ares/DNSResolver_c-ares.swift
@@ -50,12 +50,12 @@ public class CAresDNSResolver: DNSResolver {
     }
 
     /// See ``DNSResolver/queryCNAME(name:)``.
-    public func queryCNAME(name: String) async throws -> String {
+    public func queryCNAME(name: String) async throws -> String? {
         try await self.ares.query(type: .CNAME, name: name, replyParser: Ares.CNAMEQueryReplyParser.instance)
     }
 
     /// See ``DNSResolver/querySOA(name:)``.
-    public func querySOA(name: String) async throws -> SOARecord {
+    public func querySOA(name: String) async throws -> SOARecord? {
         try await self.ares.query(type: .SOA, name: name, replyParser: Ares.SOAQueryReplyParser.instance)
     }
 
@@ -267,7 +267,7 @@ extension Ares {
 
         init<Parser: AresQueryReplyParser>(parser: Parser, _ continuation: CheckedContinuation<Parser.Reply, Error>) {
             self._handler = { status, buffer, length in
-                guard status == ARES_SUCCESS else {
+                guard status == ARES_SUCCESS || status == ARES_ENODATA else {
                     return continuation.resume(throwing: AsyncDNSResolver.Error(code: status))
                 }
 
@@ -311,13 +311,19 @@ extension Ares {
             naddrttlsPointer.pointee = CInt(Ares.maxAddresses)
 
             let parseStatus = ares_parse_a_reply(buffer, length, nil, addrttlsPointer, naddrttlsPointer)
-            guard parseStatus == ARES_SUCCESS else {
+
+            switch parseStatus {
+            case ARES_SUCCESS:
+                let records = Array(UnsafeBufferPointer(start: addrttlsPointer, count: Int(naddrttlsPointer.pointee)))
+                    .map { ARecord($0) }
+                return records
+
+            case ARES_ENODATA:
+                return []
+
+            default:
                 throw AsyncDNSResolver.Error(code: parseStatus, "failed to parse A query reply")
             }
-
-            let records = Array(UnsafeBufferPointer(start: addrttlsPointer, count: Int(naddrttlsPointer.pointee)))
-                .map { ARecord($0) }
-            return records
         }
     }
 
@@ -334,13 +340,19 @@ extension Ares {
             naddrttlsPointer.pointee = CInt(Ares.maxAddresses)
 
             let parseStatus = ares_parse_aaaa_reply(buffer, length, nil, addrttlsPointer, naddrttlsPointer)
-            guard parseStatus == ARES_SUCCESS else {
+
+            switch parseStatus {
+            case ARES_SUCCESS:
+                let records = Array(UnsafeBufferPointer(start: addrttlsPointer, count: Int(naddrttlsPointer.pointee)))
+                    .map { AAAARecord($0) }
+                return records
+
+            case ARES_ENODATA:
+                return []
+
+            default:
                 throw AsyncDNSResolver.Error(code: parseStatus, "failed to parse AAAA query reply")
             }
-
-            let records = Array(UnsafeBufferPointer(start: addrttlsPointer, count: Int(naddrttlsPointer.pointee)))
-                .map { AAAARecord($0) }
-            return records
         }
     }
 
@@ -352,64 +364,80 @@ extension Ares {
             defer { hostentPtrPtr.deallocate() }
 
             let parseStatus = ares_parse_ns_reply(buffer, length, hostentPtrPtr)
-            guard parseStatus == ARES_SUCCESS else {
+
+            switch parseStatus {
+            case ARES_SUCCESS:
+                guard let hostent = hostentPtrPtr.pointee?.pointee else {
+                    return NSRecord(nameservers: [])
+                }
+
+                let nameServers = toStringArray(hostent.h_aliases)
+                return NSRecord(nameservers: nameServers ?? [])
+
+            case ARES_ENODATA:
+                return NSRecord(nameservers: [])
+
+            default:
                 throw AsyncDNSResolver.Error(code: parseStatus, "failed to parse NS query reply")
             }
-
-            guard let hostent = hostentPtrPtr.pointee?.pointee else {
-                throw AsyncDNSResolver.Error(code: .noData, message: "no NS records found")
-            }
-
-            let nameServers = toStringArray(hostent.h_aliases)
-            return NSRecord(nameservers: nameServers ?? [])
         }
     }
 
     struct CNAMEQueryReplyParser: AresQueryReplyParser {
         static let instance = CNAMEQueryReplyParser()
 
-        func parse(buffer: UnsafeMutablePointer<CUnsignedChar>?, length: CInt) throws -> String {
+        func parse(buffer: UnsafeMutablePointer<CUnsignedChar>?, length: CInt) throws -> String? {
             let hostentPtrPtr = UnsafeMutablePointer<UnsafeMutablePointer<hostent>?>.allocate(capacity: 1)
             defer { hostentPtrPtr.deallocate() }
 
             let parseStatus = ares_parse_a_reply(buffer, length, hostentPtrPtr, nil, nil)
-            guard parseStatus == ARES_SUCCESS else {
+
+            switch parseStatus {
+            case ARES_SUCCESS:
+                guard let hostent = hostentPtrPtr.pointee?.pointee else {
+                    return nil
+                }
+                return String(cString: hostent.h_name)
+
+            case ARES_ENODATA:
+                return nil
+            default:
                 throw AsyncDNSResolver.Error(code: parseStatus, "failed to parse CNAME query reply")
             }
-
-            guard let hostent = hostentPtrPtr.pointee?.pointee else {
-                throw AsyncDNSResolver.Error(code: .noData, message: "no CNAME record found")
-            }
-
-            return String(cString: hostent.h_name)
         }
     }
 
     struct SOAQueryReplyParser: AresQueryReplyParser {
         static let instance = SOAQueryReplyParser()
 
-        func parse(buffer: UnsafeMutablePointer<CUnsignedChar>?, length: CInt) throws -> SOARecord {
+        func parse(buffer: UnsafeMutablePointer<CUnsignedChar>?, length: CInt) throws -> SOARecord? {
             let soaReplyPtrPtr = UnsafeMutablePointer<UnsafeMutablePointer<ares_soa_reply>?>.allocate(capacity: 1)
             defer { soaReplyPtrPtr.deallocate() }
 
             let parseStatus = ares_parse_soa_reply(buffer, length, soaReplyPtrPtr)
-            guard parseStatus == ARES_SUCCESS else {
+            switch parseStatus {
+            case ARES_SUCCESS:
+                guard let soaReply = soaReplyPtrPtr.pointee?.pointee else {
+                    return nil
+                }
+
+                return SOARecord(
+                    mname: soaReply.nsname.map { String(cString: $0) },
+                    rname: soaReply.hostmaster.map { String(cString: $0) },
+                    serial: soaReply.serial,
+                    refresh: soaReply.refresh,
+                    retry: soaReply.retry,
+                    expire: soaReply.expire,
+                    ttl: soaReply.minttl
+                )
+
+            case ARES_ENODATA:
+                return nil
+
+            default:
                 throw AsyncDNSResolver.Error(code: parseStatus, "failed to parse SOA query reply")
             }
 
-            guard let soaReply = soaReplyPtrPtr.pointee?.pointee else {
-                throw AsyncDNSResolver.Error(code: .noData, message: "no SOA record found")
-            }
-
-            return SOARecord(
-                mname: soaReply.nsname.map { String(cString: $0) },
-                rname: soaReply.hostmaster.map { String(cString: $0) },
-                serial: soaReply.serial,
-                refresh: soaReply.refresh,
-                retry: soaReply.retry,
-                expire: soaReply.expire,
-                ttl: soaReply.minttl
-            )
         }
     }
 
@@ -423,16 +451,22 @@ extension Ares {
             defer { hostentPtrPtr.deallocate() }
 
             let parseStatus = ares_parse_ptr_reply(buffer, length, dummyAddrPointer, INET_ADDRSTRLEN, AF_INET, hostentPtrPtr)
-            guard parseStatus == ARES_SUCCESS else {
+
+            switch parseStatus {
+            case ARES_SUCCESS:
+                guard let hostent = hostentPtrPtr.pointee?.pointee else {
+                    return PTRRecord(names: [])
+                }
+
+                let hostnames = toStringArray(hostent.h_aliases)
+                return PTRRecord(names: hostnames ?? [])
+
+            case ARES_ENODATA:
+                return PTRRecord(names: [])
+
+            default:
                 throw AsyncDNSResolver.Error(code: parseStatus, "failed to parse PTR query record")
             }
-
-            guard let hostent = hostentPtrPtr.pointee?.pointee else {
-                throw AsyncDNSResolver.Error(code: .noData, message: "no PTR record found")
-            }
-
-            let hostnames = toStringArray(hostent.h_aliases)
-            return PTRRecord(names: hostnames ?? [])
         }
     }
 
@@ -444,22 +478,27 @@ extension Ares {
             defer { mxsPointer.deallocate() }
 
             let parseStatus = ares_parse_mx_reply(buffer, length, mxsPointer)
-            guard parseStatus == ARES_SUCCESS else {
+            switch parseStatus {
+            case ARES_SUCCESS:
+                var mxRecords = [MXRecord]()
+                var mxRecordOptional = mxsPointer.pointee?.pointee
+                while let mxRecord = mxRecordOptional {
+                    mxRecords.append(
+                        MXRecord(
+                            host: String(cString: mxRecord.host),
+                            priority: mxRecord.priority
+                        )
+                    )
+                    mxRecordOptional = mxRecord.next?.pointee
+                }
+                return mxRecords
+
+            case ARES_ENODATA:
+                return []
+
+            default:
                 throw AsyncDNSResolver.Error(code: parseStatus, "failed to parse MX query record")
             }
-
-            var mxRecords = [MXRecord]()
-            var mxRecordOptional = mxsPointer.pointee?.pointee
-            while let mxRecord = mxRecordOptional {
-                mxRecords.append(
-                    MXRecord(
-                        host: String(cString: mxRecord.host),
-                        priority: mxRecord.priority
-                    )
-                )
-                mxRecordOptional = mxRecord.next?.pointee
-            }
-            return mxRecords
         }
     }
 
@@ -471,21 +510,27 @@ extension Ares {
             defer { txtsPointer.deallocate() }
 
             let parseStatus = ares_parse_txt_reply(buffer, length, txtsPointer)
-            guard parseStatus == ARES_SUCCESS else {
+
+            switch parseStatus {
+            case ARES_SUCCESS:
+                var txtRecords = [TXTRecord]()
+                var txtRecordOptional = txtsPointer.pointee?.pointee
+                while let txtRecord = txtRecordOptional {
+                    txtRecords.append(
+                        TXTRecord(
+                            txt: String(cString: txtRecord.txt)
+                        )
+                    )
+                    txtRecordOptional = txtRecord.next?.pointee
+                }
+                return txtRecords
+
+            case ARES_ENODATA:
+                return []
+
+            default:
                 throw AsyncDNSResolver.Error(code: parseStatus, "failed to parse TXT query reply")
             }
-
-            var txtRecords = [TXTRecord]()
-            var txtRecordOptional = txtsPointer.pointee?.pointee
-            while let txtRecord = txtRecordOptional {
-                txtRecords.append(
-                    TXTRecord(
-                        txt: String(cString: txtRecord.txt)
-                    )
-                )
-                txtRecordOptional = txtRecord.next?.pointee
-            }
-            return txtRecords
         }
     }
 
@@ -497,24 +542,30 @@ extension Ares {
             defer { replyPointer.deallocate() }
 
             let parseStatus = ares_parse_srv_reply(buffer, length, replyPointer)
-            guard parseStatus == ARES_SUCCESS else {
+
+            switch parseStatus {
+            case ARES_SUCCESS:
+                var srvRecords = [SRVRecord]()
+                var srvRecordOptional = replyPointer.pointee?.pointee
+                while let srvRecord = srvRecordOptional {
+                    srvRecords.append(
+                        SRVRecord(
+                            host: String(cString: srvRecord.host),
+                            port: srvRecord.port,
+                            weight: srvRecord.weight,
+                            priority: srvRecord.priority
+                        )
+                    )
+                    srvRecordOptional = srvRecord.next?.pointee
+                }
+                return srvRecords
+
+            case ARES_ENODATA:
+                return []
+
+            default:
                 throw AsyncDNSResolver.Error(code: parseStatus, "failed to parse SRV query reply")
             }
-
-            var srvRecords = [SRVRecord]()
-            var srvRecordOptional = replyPointer.pointee?.pointee
-            while let srvRecord = srvRecordOptional {
-                srvRecords.append(
-                    SRVRecord(
-                        host: String(cString: srvRecord.host),
-                        port: srvRecord.port,
-                        weight: srvRecord.weight,
-                        priority: srvRecord.priority
-                    )
-                )
-                srvRecordOptional = srvRecord.next?.pointee
-            }
-            return srvRecords
         }
     }
 
@@ -526,26 +577,33 @@ extension Ares {
             defer { naptrsPointer.deallocate() }
 
             let parseStatus = ares_parse_naptr_reply(buffer, length, naptrsPointer)
-            guard parseStatus == ARES_SUCCESS else {
+
+            switch parseStatus {
+            case ARES_SUCCESS:
+                var naptrRecords = [NAPTRRecord]()
+                var naptrRecordOptional = naptrsPointer.pointee?.pointee
+                while let naptrRecord = naptrRecordOptional {
+                    naptrRecords.append(
+                        NAPTRRecord(
+                            flags: String(cString: naptrRecord.flags),
+                            service: String(cString: naptrRecord.service),
+                            regExp: String(cString: naptrRecord.regexp),
+                            replacement: String(cString: naptrRecord.replacement),
+                            order: naptrRecord.order,
+                            preference: naptrRecord.preference
+                        )
+                    )
+                    naptrRecordOptional = naptrRecord.next?.pointee
+                }
+                return naptrRecords
+
+            case ARES_ENODATA:
+                return []
+
+            default:
                 throw AsyncDNSResolver.Error(code: parseStatus, "failed to parse NAPTR query reply")
             }
 
-            var naptrRecords = [NAPTRRecord]()
-            var naptrRecordOptional = naptrsPointer.pointee?.pointee
-            while let naptrRecord = naptrRecordOptional {
-                naptrRecords.append(
-                    NAPTRRecord(
-                        flags: String(cString: naptrRecord.flags),
-                        service: String(cString: naptrRecord.service),
-                        regExp: String(cString: naptrRecord.regexp),
-                        replacement: String(cString: naptrRecord.replacement),
-                        order: naptrRecord.order,
-                        preference: naptrRecord.preference
-                    )
-                )
-                naptrRecordOptional = naptrRecord.next?.pointee
-            }
-            return naptrRecords
         }
     }
 }

--- a/Sources/AsyncDNSResolver/c-ares/Errors_c-ares.swift
+++ b/Sources/AsyncDNSResolver/c-ares/Errors_c-ares.swift
@@ -19,8 +19,6 @@ extension AsyncDNSResolver.Error {
     /// Create an ``AsyncDNSResolver/AsyncDNSResolver/Error`` from c-ares error code.
     init(code: Int32, _ description: String = "") {
         switch code {
-        case ARES_ENODATA:
-            self = .init(code: .noData, message: description)
         case ARES_EFORMERR:
             self = .init(code: .invalidQuery, message: description)
         case ARES_ESERVFAIL:

--- a/Tests/AsyncDNSResolverTests/c-ares/AresErrorTests.swift
+++ b/Tests/AsyncDNSResolverTests/c-ares/AresErrorTests.swift
@@ -18,10 +18,10 @@ import XCTest
 
 final class AresErrorTests: XCTestCase {
     func test_initFromCode() {
-        let code = ARES_ENODATA
+        let code = ARES_EFORMERR
         let error = AsyncDNSResolver.Error(code: code, "some error")
 
-        XCTAssertEqual(error.code, .noData)
+        XCTAssertEqual(error.code, .invalidQuery)
         XCTAssertEqual(error.message, "some error", "Expected description to be \"some error\", got \(error.message)")
     }
 }

--- a/Tests/AsyncDNSResolverTests/c-ares/CAresDNSResolverTests.swift
+++ b/Tests/AsyncDNSResolverTests/c-ares/CAresDNSResolverTests.swift
@@ -159,14 +159,14 @@ final class CAresDNSResolverTests: XCTestCase {
         try await run { i in
             let reply = try await self.resolver.queryCNAME(name: "www.apple.com")
             if self.verbose {
-                print("[CNAME] run #\(i) result: \(reply)")
+                print("[CNAME] run #\(i) result: \(String(describing: reply))")
             }
         }
 
         try await run { i in
             let reply = try await self.resolver.querySOA(name: "apple.com")
             if self.verbose {
-                print("[SOA] run #\(i) result: \(reply)")
+                print("[SOA] run #\(i) result: \(String(describing: reply))")
             }
         }
 

--- a/Tests/AsyncDNSResolverTests/c-ares/CAresDNSResolverTests.swift
+++ b/Tests/AsyncDNSResolverTests/c-ares/CAresDNSResolverTests.swift
@@ -63,17 +63,17 @@ final class CAresDNSResolverTests: XCTestCase {
     func test_queryCNAME() async throws {
         let reply = try await self.resolver.queryCNAME(name: "www.apple.com")
         if self.verbose {
-            print("test_queryCNAME: \(reply)")
+            print("test_queryCNAME: \(String(describing: reply))")
         }
-        XCTAssertFalse(reply.isEmpty, "should have CNAME")
+        XCTAssertNotNil(reply?.isEmpty ?? true, "should have CNAME")
     }
 
     func test_querySOA() async throws {
         let reply = try await self.resolver.querySOA(name: "apple.com")
         if self.verbose {
-            print("test_querySOA: \(reply)")
+            print("test_querySOA: \(String(describing: reply))")
         }
-        XCTAssertFalse(reply.mname?.isEmpty ?? true, "should have nameserver")
+        XCTAssertFalse(reply?.mname?.isEmpty ?? true, "should have nameserver")
     }
 
     func test_queryPTR() async throws {

--- a/Tests/AsyncDNSResolverTests/dnssd/DNSSDDNSResolverTests.swift
+++ b/Tests/AsyncDNSResolverTests/dnssd/DNSSDDNSResolverTests.swift
@@ -59,17 +59,17 @@ final class DNSSDDNSResolverTests: XCTestCase {
     func test_queryCNAME() async throws {
         let reply = try await self.resolver.queryCNAME(name: "www.apple.com")
         if self.verbose {
-            print("test_queryCNAME: \(reply)")
+            print("test_queryCNAME: \(String(describing: reply))")
         }
-        XCTAssertFalse(reply.isEmpty, "should have CNAME")
+        XCTAssertFalse(reply?.isEmpty ?? true, "should have CNAME")
     }
 
     func test_querySOA() async throws {
         let reply = try await self.resolver.querySOA(name: "apple.com")
         if self.verbose {
-            print("test_querySOA: \(reply)")
+            print("test_querySOA: \(String(describing: reply))")
         }
-        XCTAssertFalse(reply.mname?.isEmpty ?? true, "should have nameserver")
+        XCTAssertFalse(reply?.mname?.isEmpty ?? true, "should have nameserver")
     }
 
     func test_queryPTR() async throws {


### PR DESCRIPTION
Motivation:

The AsyncDNSResolver currently throws an error when there are no records associated with a name. However, most query responses are arrays or contain arrays. As such it's unclear to callers whether they should be catching an error of a particular type or checking for the presence of values some combination of the two.

Modifications:

- Modify the `DNSResolver` API to return `nil` where only a single value is expected (e.g. CNAME).
- Update documentation on `DNSResolver` to clarify the expected return values when no values are resolved.
- Update the c-ares backend to check for no data when parsing and return empty responses
- Update the DNSSD backend to pass in `nil` data to the parser when the status is timeout
- Remove the `noData` error code as it shouldn't be reachable anymore

Result:

Queries with no response either return empty or nil