### PR TITLE
Avoid memory leak from hostent

### DIFF
--- a/Sources/AsyncDNSResolver/c-ares/DNSResolver_c-ares.swift
+++ b/Sources/AsyncDNSResolver/c-ares/DNSResolver_c-ares.swift
@@ -303,12 +303,6 @@ extension Ares {
         static let instance = AQueryReplyParser()
 
         func parse(buffer: UnsafeMutablePointer<CUnsignedChar>?, length: CInt) throws -> [ARecord] {
-            // `hostent` is not needed, but if we don't allocate and pass it as an arg c-ares will allocate one
-            // and free it automatically, and that might cause TSAN errors in `ares_free_hostent`. If we allocate
-            // it then we control when it's freed.
-            let hostentPtrPtr = UnsafeMutablePointer<UnsafeMutablePointer<hostent>?>.allocate(capacity: 1)
-            defer { hostentPtrPtr.deallocate() }
-
             let addrttlsPointer = UnsafeMutablePointer<ares_addrttl>.allocate(capacity: Ares.maxAddresses)
             defer { addrttlsPointer.deallocate() }
             let naddrttlsPointer = UnsafeMutablePointer<CInt>.allocate(capacity: 1)
@@ -317,7 +311,7 @@ extension Ares {
             // Set a limit or else addrttl array won't be populated
             naddrttlsPointer.pointee = CInt(Ares.maxAddresses)
 
-            let parseStatus = ares_parse_a_reply(buffer, length, hostentPtrPtr, addrttlsPointer, naddrttlsPointer)
+            let parseStatus = ares_parse_a_reply(buffer, length, nil, addrttlsPointer, naddrttlsPointer)
             guard parseStatus == ARES_SUCCESS else {
                 throw AsyncDNSResolver.Error(code: parseStatus, "failed to parse A query reply")
             }
@@ -332,12 +326,6 @@ extension Ares {
         static let instance = AAAAQueryReplyParser()
 
         func parse(buffer: UnsafeMutablePointer<CUnsignedChar>?, length: CInt) throws -> [AAAARecord] {
-            // `hostent` is not needed, but if we don't allocate and pass it as an arg c-ares will allocate one
-            // and free it automatically, and that might cause TSAN errors in `ares_free_hostent`. If we allocate
-            // it then we control when it's freed.
-            let hostentPtrPtr = UnsafeMutablePointer<UnsafeMutablePointer<hostent>?>.allocate(capacity: 1)
-            defer { hostentPtrPtr.deallocate() }
-
             let addrttlsPointer = UnsafeMutablePointer<ares_addr6ttl>.allocate(capacity: Ares.maxAddresses)
             defer { addrttlsPointer.deallocate() }
             let naddrttlsPointer = UnsafeMutablePointer<CInt>.allocate(capacity: 1)
@@ -346,7 +334,7 @@ extension Ares {
             // Set a limit or else addrttl array won't be populated
             naddrttlsPointer.pointee = CInt(Ares.maxAddresses)
 
-            let parseStatus = ares_parse_aaaa_reply(buffer, length, hostentPtrPtr, addrttlsPointer, naddrttlsPointer)
+            let parseStatus = ares_parse_aaaa_reply(buffer, length, nil, addrttlsPointer, naddrttlsPointer)
             guard parseStatus == ARES_SUCCESS else {
                 throw AsyncDNSResolver.Error(code: parseStatus, "failed to parse AAAA query reply")
             }


### PR DESCRIPTION
More context on issue #29 


### Motivation

Observed memory leak in Leaks instrument caused by A and AAAA queries.

### Modifications

hostent is internally allocated by ares_parse_a_reply when we pass non-null pointer, and it expects the caller to freehostent(hostent).

Here we pass host=null to avoid the code branch that allocates hostent [here](https://github.com/c-ares/c-ares/blob/cares-1_19_1/src/lib/ares_parse_a_reply.c#L67).  It looks like this is fine since we don't need hostent.

### Result

No hostent is allocated, leak count significantly reduced.

For reference, reduced from 2k leaks to 600 leaks, when resolving about ~200 domains (A and AAAA records)

### Test Plan

_[Describe the steps you took, or will take, to qualify the change - such as adjusting tests and manual testing.]_
