### PR TITLE
Fix continuation memory leak in Ares.query

### DIFF
--- a/Sources/AsyncDNSResolver/c-ares/DNSResolver_c-ares.swift
+++ b/Sources/AsyncDNSResolver/c-ares/DNSResolver_c-ares.swift
@@ -160,8 +160,12 @@ class Ares {
                             preconditionFailure("'arg' is nil. This is a bug.")
                         }
 
-                        let handler = QueryReplyHandler(pointer: handlerPointer)
-                        defer { handlerPointer.deallocate() }
+                        let pointer = handlerPointer.assumingMemoryBound(to: QueryReplyHandler.self)
+                        let handler = pointer.pointee
+                        defer {
+                            pointer.deinitialize(count: 1)
+                            pointer.deallocate()
+                        }
 
                         handler.handle(status: status, buffer: buf, length: len)
                     }
@@ -274,11 +278,6 @@ extension Ares {
                     continuation.resume(throwing: error)
                 }
             }
-        }
-
-        init(pointer: UnsafeMutableRawPointer) {
-            let handlerPointer = pointer.assumingMemoryBound(to: Self.self)
-            self = handlerPointer.pointee
         }
 
         func handle(status: CInt, buffer: UnsafeMutablePointer<CUnsignedChar>?, length: CInt) {

--- a/Sources/AsyncDNSResolver/c-ares/DNSResolver_c-ares.swift
+++ b/Sources/AsyncDNSResolver/c-ares/DNSResolver_c-ares.swift
@@ -262,7 +262,7 @@ extension Ares {
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension Ares {
-    struct QueryReplyHandler {
+    class QueryReplyHandler {
         private let _handler: (CInt, UnsafeMutablePointer<CUnsignedChar>?, CInt) -> Void
 
         init<Parser: AresQueryReplyParser>(parser: Parser, _ continuation: CheckedContinuation<Parser.Reply, Error>) {

--- a/Sources/AsyncDNSResolver/dnssd/DNSResolver_dnssd.swift
+++ b/Sources/AsyncDNSResolver/dnssd/DNSResolver_dnssd.swift
@@ -116,7 +116,11 @@ struct DNSSD {
                 alignment: MemoryLayout<QueryReplyHandler>.alignment
             )
             // The handler might be called multiple times so don't deallocate inside `callback`
-            defer { handlerPointer.deallocate() }
+            defer {
+                let pointer = handlerPointer.assumingMemoryBound(to: QueryReplyHandler.self)
+                pointer.deinitialize(count: 1)
+                pointer.deallocate()
+            }
 
             handlerPointer.initializeMemory(as: QueryReplyHandler.self, repeating: handler, count: 1)
 


### PR DESCRIPTION
### Motivation

#29 

### Modifications

Frankly not too sure exactly why this fixes the leak (Swift noob here), but it may be that `pointer.deallocate()` only frees the pointer, and not the underlying initialized.

### Result

QueryReplyHandler gets deallocated properly and so does the continuation that was leaking. 

Leaks from [this](https://github.com/apple/swift-async-dns-resolver/blob/main/Sources/AsyncDNSResolver/c-ares/DNSResolver_c-ares.swift#L148) are gone when running A/AAAA queries.

### Test Plan

Running Xcode leaks instrument in my app, some code examples in #29 .
