### PR TITLE
Move to Swift tools version 5.9

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.9
 
 import PackageDescription
 


### PR DESCRIPTION
Motivation:

The support and test commitment is to work for the last 3 version of swift.  This aligns supported versions with tested versions.

Modifications:

Move to Swift tools version 5.9 in Package.swift

Result:

Only Swift >=5.9 supported