### PR TITLE
Enable strict concurrency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -50,3 +50,9 @@ let package = Package(
     ],
     cLanguageStandard: .gnu11
 )
+
+for target in package.targets {
+    var settings = target.swiftSettings ?? []
+    settings.append(.enableExperimentalFeature("StrictConcurrency=complete"))
+    target.swiftSettings = settings
+}

--- a/Sources/AsyncDNSResolver/c-ares/AresOptions.swift
+++ b/Sources/AsyncDNSResolver/c-ares/AresOptions.swift
@@ -19,7 +19,7 @@ import CAsyncDNSResolver
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension CAresDNSResolver {
     /// Options for ``CAresDNSResolver``.
-    public struct Options {
+    public struct Options: Sendable {
         public static var `default`: Options {
             .init()
         }
@@ -91,7 +91,7 @@ extension CAresDNSResolver {
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension CAresDNSResolver.Options {
-    public struct Flags: OptionSet {
+    public struct Flags: OptionSet, Sendable {
         public let rawValue: Int32
 
         public init(rawValue: Int32) {

--- a/Sources/AsyncDNSResolver/dnssd/DNSResolver_dnssd.swift
+++ b/Sources/AsyncDNSResolver/dnssd/DNSResolver_dnssd.swift
@@ -17,7 +17,7 @@ import dnssd
 
 /// ``DNSResolver`` implementation backed by dnssd framework.
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-public struct DNSSDDNSResolver: DNSResolver {
+public struct DNSSDDNSResolver: DNSResolver, Sendable {
     let dnssd: DNSSD
 
     init() {
@@ -100,7 +100,7 @@ extension QueryType {
 // MARK: - dnssd query wrapper
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
-struct DNSSD {
+struct DNSSD: Sendable {
     // Reference: https://gist.github.com/fikeminkel/a9c4bc4d0348527e8df3690e242038d3
     func query<ReplyHandler: DNSSDQueryReplyHandler>(
         type: QueryType,
@@ -225,7 +225,7 @@ extension DNSSD {
 // MARK: - dnssd query reply handlers
 
 protocol DNSSDQueryReplyHandler {
-    associatedtype Record
+    associatedtype Record: Sendable
     associatedtype Reply
 
     func parseRecord(data: UnsafeRawPointer?, length: UInt16) throws -> Record?

--- a/Tests/AsyncDNSResolverTests/c-ares/AresChannelTests.swift
+++ b/Tests/AsyncDNSResolverTests/c-ares/AresChannelTests.swift
@@ -29,7 +29,7 @@ final class AresChannelTests: XCTestCase {
         guard let channel = try? AresChannel(options: options) else {
             return XCTFail("Channel not initialized")
         }
-        guard let _ = channel.pointer.pointee else {
+        guard let _ = channel.underlying else {
             return XCTFail("Underlying ares_channel is nil")
         }
     }

--- a/Tests/AsyncDNSResolverTests/c-ares/CAresDNSResolverTests.swift
+++ b/Tests/AsyncDNSResolverTests/c-ares/CAresDNSResolverTests.swift
@@ -124,7 +124,7 @@ final class CAresDNSResolverTests: XCTestCase {
     func test_concurrency() async throws {
         func run(
             times: Int = 100,
-            _ query: @escaping (_ index: Int) async throws -> Void
+            _ query: @Sendable @escaping (_ index: Int) async throws -> Void
         ) async throws {
             try await withThrowingTaskGroup(of: Void.self) { group in
                 for i in 1...times {
@@ -136,65 +136,67 @@ final class CAresDNSResolverTests: XCTestCase {
             }
         }
 
+        let resolver = self.resolver!
+        let verbose = self.verbose
         try await run { i in
-            let reply = try await self.resolver.queryA(name: "apple.com")
-            if self.verbose {
+            let reply = try await resolver.queryA(name: "apple.com")
+            if verbose {
                 print("[A] run #\(i) result: \(reply)")
             }
         }
 
         try await run { i in
-            let reply = try await self.resolver.queryAAAA(name: "apple.com")
-            if self.verbose {
+            let reply = try await resolver.queryAAAA(name: "apple.com")
+            if verbose {
                 print("[AAAA] run #\(i) result: \(reply)")
             }
         }
 
         try await run { i in
-            let reply = try await self.resolver.queryNS(name: "apple.com")
-            if self.verbose {
+            let reply = try await resolver.queryNS(name: "apple.com")
+            if verbose {
                 print("[NS] run #\(i) result: \(reply)")
             }
         }
 
         try await run { i in
-            let reply = try await self.resolver.queryCNAME(name: "www.apple.com")
-            if self.verbose {
+            let reply = try await resolver.queryCNAME(name: "www.apple.com")
+            if verbose {
                 print("[CNAME] run #\(i) result: \(String(describing: reply))")
             }
         }
 
         try await run { i in
-            let reply = try await self.resolver.querySOA(name: "apple.com")
-            if self.verbose {
+            let reply = try await resolver.querySOA(name: "apple.com")
+            if verbose {
                 print("[SOA] run #\(i) result: \(String(describing: reply))")
             }
         }
 
         try await run { i in
-            let reply = try await self.resolver.queryPTR(name: "47.224.172.17.in-addr.arpa")
-            if self.verbose {
+            let reply = try await resolver.queryPTR(name: "47.224.172.17.in-addr.arpa")
+            if verbose {
                 print("[PTR] run #\(i) result: \(reply)")
             }
         }
 
         try await run { i in
-            let reply = try await self.resolver.queryMX(name: "apple.com")
-            if self.verbose {
+            let reply = try await resolver.queryMX(name: "apple.com")
+            if verbose {
                 print("[MX] run #\(i) result: \(reply)")
             }
         }
 
         try await run { i in
-            let reply = try await self.resolver.queryTXT(name: "apple.com")
-            if self.verbose {
+            let reply = try await resolver.queryTXT(name: "apple.com")
+            if verbose {
                 print("[TXT] run #\(i) result: \(reply)")
             }
         }
 
         try await run { i in
-            let reply = try await self.resolver.querySRV(name: "_caldavs._tcp.google.com")
-            if self.verbose {
+            let reply = try await resolver.querySRV(name: "_caldavs._tcp.google.com")
+            if verbose {
                 print("[SRV] run #\(i) result: \(reply)")
             }
         }

--- a/Tests/AsyncDNSResolverTests/dnssd/DNSSDDNSResolverTests.swift
+++ b/Tests/AsyncDNSResolverTests/dnssd/DNSSDDNSResolverTests.swift
@@ -143,7 +143,7 @@ final class DNSSDDNSResolverTests: XCTestCase {
     func test_concurrency() async throws {
         func run(
             times: Int = 100,
-            _ query: @escaping (_ index: Int) async throws -> Void
+            _ query: @Sendable @escaping (_ index: Int) async throws -> Void
         ) async throws {
             try await withThrowingTaskGroup(of: Void.self) { group in
                 for i in 1...times {
@@ -155,65 +155,67 @@ final class DNSSDDNSResolverTests: XCTestCase {
             }
         }
 
+        let resolver = self.resolver!
+        let verbose = self.verbose
         try await run { i in
-            let reply = try await self.resolver.queryA(name: "apple.com")
-            if self.verbose {
+            let reply = try await resolver.queryA(name: "apple.com")
+            if verbose {
                 print("[A] run #\(i) result: \(reply)")
             }
         }
 
         try await run { i in
-            let reply = try await self.resolver.queryAAAA(name: "apple.com")
-            if self.verbose {
+            let reply = try await resolver.queryAAAA(name: "apple.com")
+            if verbose {
                 print("[AAAA] run #\(i) result: \(reply)")
             }
         }
 
         try await run { i in
-            let reply = try await self.resolver.queryNS(name: "apple.com")
-            if self.verbose {
+            let reply = try await resolver.queryNS(name: "apple.com")
+            if verbose {
                 print("[NS] run #\(i) result: \(reply)")
             }
         }
 
         try await run { i in
-            let reply = try await self.resolver.queryCNAME(name: "www.apple.com")
-            if self.verbose {
+            let reply = try await resolver.queryCNAME(name: "www.apple.com")
+            if verbose {
                 print("[CNAME] run #\(i) result: \(String(describing: reply))")
             }
         }
 
         try await run { i in
-            let reply = try await self.resolver.querySOA(name: "apple.com")
-            if self.verbose {
+            let reply = try await resolver.querySOA(name: "apple.com")
+            if verbose {
                 print("[SOA] run #\(i) result: \(String(describing: reply))")
             }
         }
 
         try await run { i in
-            let reply = try await self.resolver.queryPTR(name: "47.224.172.17.in-addr.arpa")
-            if self.verbose {
+            let reply = try await resolver.queryPTR(name: "47.224.172.17.in-addr.arpa")
+            if verbose {
                 print("[PTR] run #\(i) result: \(reply)")
             }
         }
 
         try await run { i in
-            let reply = try await self.resolver.queryMX(name: "apple.com")
-            if self.verbose {
+            let reply = try await resolver.queryMX(name: "apple.com")
+            if verbose {
                 print("[MX] run #\(i) result: \(reply)")
             }
         }
 
         try await run { i in
-            let reply = try await self.resolver.queryTXT(name: "apple.com")
-            if self.verbose {
+            let reply = try await resolver.queryTXT(name: "apple.com")
+            if verbose {
                 print("[TXT] run #\(i) result: \(reply)")
             }
         }
 
         try await run { i in
-            let reply = try await self.resolver.querySRV(name: "_caldavs._tcp.google.com")
-            if self.verbose {
+            let reply = try await resolver.querySRV(name: "_caldavs._tcp.google.com")
+            if verbose {
                 print("[SRV] run #\(i) result: \(reply)")
             }
         }


### PR DESCRIPTION
### Motivation:

Catch potential data races at build time.

### Modifications:

- Enabled strict concurrency checking in the Package.swift.
- Made a few types Sendable: `AresChannel`, `CAresDNSResolver`, `Ares`, `QueryProcessor`, `DNSSDDNSResolver`.

### Result:

Fewer potential data races can sneak in.

### Test Plan

Ran tests locally, did not see any concurrency warnings or errors, all tests passed.
