### PR TITLE
Bump c-ares 1.19.1 to 1.34.6

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,8 @@ var caresExclude = [
     "./c-ares/src/lib/ares_config.h.cmake",
     "./c-ares/src/lib/Makefile.am",
     "./c-ares/src/lib/Makefile.inc",
+    "./c-ares/src/lib/include/README.md",
+    "./c-ares/src/lib/thirdparty/apple/README.md",
 ]
 
 do {
@@ -35,6 +37,7 @@ let package = Package(
             cSettings: [
                 .headerSearchPath("./c-ares/include"),
                 .headerSearchPath("./c-ares/src/lib"),
+                .headerSearchPath("./c-ares/src/lib/include"),
                 .define("HAVE_CONFIG_H", to: "1"),
             ]
         ),

--- a/Sources/AsyncDNSResolver/c-ares/AresChannel.swift
+++ b/Sources/AsyncDNSResolver/c-ares/AresChannel.swift
@@ -69,7 +69,7 @@ final class AresChannel: @unchecked Sendable {
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 private func checkAresResult(body: () -> Int32) throws {
     let result = body()
-    guard result == ARES_SUCCESS else {
+    guard ares_status_t(result) == ARES_SUCCESS else {
         throw AsyncDNSResolver.Error(cAresCode: result, "failed to initialize channel")
     }
 }

--- a/Sources/AsyncDNSResolver/c-ares/AresChannel.swift
+++ b/Sources/AsyncDNSResolver/c-ares/AresChannel.swift
@@ -21,6 +21,11 @@ import Foundation
 final class AresChannel: @unchecked Sendable {
     private let locked_pointer: UnsafeMutablePointer<ares_channel?>
     private let lock = NSLock()
+    // Owned here so its lifetime exactly brackets the channel's: c-ares holds only an
+    // unmanaged pointer to it (via `sock_state_cb_data`), and `ares_destroy` (in `deinit`)
+    // may invoke the socket-state callback while closing sockets. Being a stored property,
+    // it stays alive until after `deinit`'s body runs. `QueryProcessor` reads it to poll.
+    let socketRegistry: SocketRegistry
 
     // For testing only.
     var underlying: ares_channel? {
@@ -36,6 +41,22 @@ final class AresChannel: @unchecked Sendable {
     }
 
     init(options: AresOptions) throws {
+        let socketRegistry = SocketRegistry()
+
+        // c-ares invokes this whenever a socket is opened/closed or its read/write interest
+        // changes. It must be registered on the options *before* `ares_init_options`, and being
+        // `@convention(c)` it cannot capture context, so the registry is threaded through
+        // `sock_state_cb_data` as an unmanaged pointer (kept valid by `self.socketRegistry`).
+        let socketStateCallback: SocketStateCallback = { data, socket, readable, writable in
+            guard let data = data else { return }
+            let registry = Unmanaged<SocketRegistry>.fromOpaque(data).takeUnretainedValue()
+            registry.update(socket: socket, readable: readable != 0, writable: writable != 0)
+        }
+        options.setSocketStateCallback(
+            with: Unmanaged.passUnretained(socketRegistry).toOpaque(),
+            socketStateCallback
+        )
+
         // Initialize c-ares
         try checkAresResult { ares_library_init(ARES_LIB_INIT_ALL) }
 
@@ -52,6 +73,7 @@ final class AresChannel: @unchecked Sendable {
             try checkAresResult { ares_set_sortlist(pointer.pointee, sortlist) }
         }
 
+        self.socketRegistry = socketRegistry
         self.locked_pointer = pointer
     }
 
@@ -71,5 +93,31 @@ private func checkAresResult(body: () -> Int32) throws {
     let result = body()
     guard ares_status_t(result) == ARES_SUCCESS else {
         throw AsyncDNSResolver.Error(cAresCode: result, "failed to initialize channel")
+    }
+}
+
+// MARK: - socket registry
+
+/// Tracks the sockets c-ares is interested in, and their read/write interest, as
+/// reported by the channel's `sock_state_cb`. Consumed by `Ares.QueryProcessor.poll()`
+/// to drive `ares_process_fd`, replacing the deprecated `ares_getsock`.
+final class SocketRegistry: @unchecked Sendable {
+    private let lock = NSLock()
+    private var locked_sockets: [Socket: (readable: Bool, writable: Bool)] = [:]
+
+    func update(socket: Socket, readable: Bool, writable: Bool) {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        if !readable, !writable {
+            self.locked_sockets.removeValue(forKey: socket)
+        } else {
+            self.locked_sockets[socket] = (readable, writable)
+        }
+    }
+
+    func snapshot() -> [(socket: Socket, readable: Bool, writable: Bool)] {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+        return self.locked_sockets.map { (socket: $0.key, readable: $0.value.readable, writable: $0.value.writable) }
     }
 }

--- a/Sources/AsyncDNSResolver/c-ares/DNSResolver_c-ares.swift
+++ b/Sources/AsyncDNSResolver/c-ares/DNSResolver_c-ares.swift
@@ -273,7 +273,7 @@ extension Ares {
 
         init<Parser: AresQueryReplyParser>(parser: Parser, _ continuation: CheckedContinuation<Parser.Reply, Error>) {
             self._handler = { status, buffer, length in
-                guard status == ARES_SUCCESS || status == ARES_ENODATA else {
+                guard ares_status_t(status) == ARES_SUCCESS || ares_status_t(status) == ARES_ENODATA else {
                     return continuation.resume(throwing: AsyncDNSResolver.Error(cAresCode: status))
                 }
 
@@ -318,7 +318,7 @@ extension Ares {
 
             let parseStatus = ares_parse_a_reply(buffer, length, nil, addrttlsPointer, naddrttlsPointer)
 
-            switch parseStatus {
+            switch ares_status_t(parseStatus) {
             case ARES_SUCCESS:
                 let records = Array(UnsafeBufferPointer(start: addrttlsPointer, count: Int(naddrttlsPointer.pointee)))
                     .map { ARecord($0) }
@@ -347,7 +347,7 @@ extension Ares {
 
             let parseStatus = ares_parse_aaaa_reply(buffer, length, nil, addrttlsPointer, naddrttlsPointer)
 
-            switch parseStatus {
+            switch ares_status_t(parseStatus) {
             case ARES_SUCCESS:
                 let records = Array(UnsafeBufferPointer(start: addrttlsPointer, count: Int(naddrttlsPointer.pointee)))
                     .map { AAAARecord($0) }
@@ -371,7 +371,7 @@ extension Ares {
 
             let parseStatus = ares_parse_ns_reply(buffer, length, hostentPtrPtr)
 
-            switch parseStatus {
+            switch ares_status_t(parseStatus) {
             case ARES_SUCCESS:
                 guard let hostent = hostentPtrPtr.pointee?.pointee else {
                     return NSRecord(nameservers: [])
@@ -398,7 +398,7 @@ extension Ares {
 
             let parseStatus = ares_parse_a_reply(buffer, length, hostentPtrPtr, nil, nil)
 
-            switch parseStatus {
+            switch ares_status_t(parseStatus) {
             case ARES_SUCCESS:
                 guard let hostent = hostentPtrPtr.pointee?.pointee else {
                     return nil
@@ -421,7 +421,7 @@ extension Ares {
             defer { soaReplyPtrPtr.deallocate() }
 
             let parseStatus = ares_parse_soa_reply(buffer, length, soaReplyPtrPtr)
-            switch parseStatus {
+            switch ares_status_t(parseStatus) {
             case ARES_SUCCESS:
                 guard let soaReply = soaReplyPtrPtr.pointee?.pointee else {
                     return nil
@@ -464,7 +464,7 @@ extension Ares {
                 hostentPtrPtr
             )
 
-            switch parseStatus {
+            switch ares_status_t(parseStatus) {
             case ARES_SUCCESS:
                 guard let hostent = hostentPtrPtr.pointee?.pointee else {
                     return PTRRecord(names: [])
@@ -490,7 +490,7 @@ extension Ares {
             defer { mxsPointer.deallocate() }
 
             let parseStatus = ares_parse_mx_reply(buffer, length, mxsPointer)
-            switch parseStatus {
+            switch ares_status_t(parseStatus) {
             case ARES_SUCCESS:
                 var mxRecords = [MXRecord]()
                 var mxRecordOptional = mxsPointer.pointee?.pointee
@@ -523,7 +523,7 @@ extension Ares {
 
             let parseStatus = ares_parse_txt_reply(buffer, length, txtsPointer)
 
-            switch parseStatus {
+            switch ares_status_t(parseStatus) {
             case ARES_SUCCESS:
                 var txtRecords = [TXTRecord]()
                 var txtRecordOptional = txtsPointer.pointee?.pointee
@@ -555,7 +555,7 @@ extension Ares {
 
             let parseStatus = ares_parse_srv_reply(buffer, length, replyPointer)
 
-            switch parseStatus {
+            switch ares_status_t(parseStatus) {
             case ARES_SUCCESS:
                 var srvRecords = [SRVRecord]()
                 var srvRecordOptional = replyPointer.pointee?.pointee
@@ -590,7 +590,7 @@ extension Ares {
 
             let parseStatus = ares_parse_naptr_reply(buffer, length, naptrsPointer)
 
-            switch parseStatus {
+            switch ares_status_t(parseStatus) {
             case ARES_SUCCESS:
                 var naptrRecords = [NAPTRRecord]()
                 var naptrRecordOptional = naptrsPointer.pointee?.pointee

--- a/Sources/AsyncDNSResolver/c-ares/DNSResolver_c-ares.swift
+++ b/Sources/AsyncDNSResolver/c-ares/DNSResolver_c-ares.swift
@@ -202,13 +202,13 @@ final class Ares: Sendable {
                         )
                         // Unlike the deprecated `ares_query`, `ares_query_dnsrec` reports a
                         // synchronous status. On failure the callback will not fire, so free
-                        // the handler here and fail the continuation, otherwise it would leak
-                        // and the caller would await forever.
+                        // the pointer here and fail via `handler`, which resumes once even if
+                        // the task is cancelled concurrently.
                         if status != ARES_SUCCESS {
                             let pointer = handlerPointer.assumingMemoryBound(to: QueryReplyHandler.self)
                             pointer.deinitialize(count: 1)
                             pointer.deallocate()
-                            continuation.resume(throwing: AsyncDNSResolver.Error(cAresCode: CInt(status.rawValue)))
+                            handler.handle(status: status, dnsrec: nil)
                         }
                     }
                 }

--- a/Sources/AsyncDNSResolver/c-ares/DNSResolver_c-ares.swift
+++ b/Sources/AsyncDNSResolver/c-ares/DNSResolver_c-ares.swift
@@ -99,29 +99,29 @@ public final class CAresDNSResolver: DNSResolver, Sendable {
 }
 
 extension QueryType {
-    fileprivate var intValue: CInt {
-        /// See `arpa/nameser.h`.
+    /// The c-ares DNS record type for this query.
+    fileprivate var aresRecType: ares_dns_rec_type_t {
         switch self {
         case .A:
-            return 1
+            return ARES_REC_TYPE_A
         case .NS:
-            return 2
+            return ARES_REC_TYPE_NS
         case .CNAME:
-            return 5
+            return ARES_REC_TYPE_CNAME
         case .SOA:
-            return 6
+            return ARES_REC_TYPE_SOA
         case .PTR:
-            return 12
+            return ARES_REC_TYPE_PTR
         case .MX:
-            return 15
+            return ARES_REC_TYPE_MX
         case .TXT:
-            return 16
+            return ARES_REC_TYPE_TXT
         case .AAAA:
-            return 28
+            return ARES_REC_TYPE_AAAA
         case .SRV:
-            return 33
+            return ARES_REC_TYPE_SRV
         case .NAPTR:
-            return 35
+            return ARES_REC_TYPE_NAPTR
         }
     }
 }
@@ -132,17 +132,19 @@ extension QueryType {
 final class Ares: Sendable {
     typealias QueryCallback =
         @convention(c) (
-            UnsafeMutableRawPointer?, CInt, CInt, UnsafeMutablePointer<CUnsignedChar>?, CInt
+            UnsafeMutableRawPointer?, ares_status_t, size_t, OpaquePointer?
         ) -> Void
 
     private let channel: AresChannel
     private let queryProcessor: QueryProcessor
 
     init(options: AresOptions) throws {
-        self.channel = try AresChannel(options: options)
+        // `AresChannel` owns the socket registry and wires the c-ares `sock_state_cb`.
+        let channel = try AresChannel(options: options)
+        self.channel = channel
 
-        // Need to call `ares_process` or `ares_process_fd` for query callbacks to happen
-        self.queryProcessor = QueryProcessor(channel: self.channel)
+        // Need to call `ares_process_fd` for query callbacks to happen
+        self.queryProcessor = QueryProcessor(channel: channel)
         self.queryProcessor.start()
     }
 
@@ -154,7 +156,8 @@ final class Ares: Sendable {
         let channel = self.channel
         return try await withTaskCancellationHandler(
             operation: {
-                try await withCheckedThrowingContinuation { continuation in
+                try await withCheckedThrowingContinuation {
+                    (continuation: CheckedContinuation<ReplyParser.Reply, Error>) in
                     let handler = QueryReplyHandler(parser: replyParser, continuation)
 
                     // Wrap `handler` into a pointer so we can pass it to callback. The pointer will be deallocated in there later.
@@ -164,7 +167,7 @@ final class Ares: Sendable {
                     )
                     handlerPointer.initializeMemory(as: QueryReplyHandler.self, repeating: handler, count: 1)
 
-                    let queryCallback: QueryCallback = { arg, status, _, buf, len in
+                    let queryCallback: QueryCallback = { arg, status, _, dnsrec in
                         guard let handlerPointer = arg else {
                             preconditionFailure("'arg' is nil. This is a bug.")
                         }
@@ -176,11 +179,29 @@ final class Ares: Sendable {
                             pointer.deallocate()
                         }
 
-                        handler.handle(status: status, buffer: buf, length: len)
+                        handler.handle(status: status, dnsrec: dnsrec)
                     }
 
                     self.channel.withChannel { channel in
-                        ares_query(channel, name, DNSClass.IN.rawValue, type.intValue, queryCallback, handlerPointer)
+                        var qid: CUnsignedShort = 0
+                        let status = ares_query_dnsrec(
+                            channel,
+                            name,
+                            ARES_CLASS_IN,
+                            type.aresRecType,
+                            queryCallback,
+                            handlerPointer,
+                            &qid
+                        )
+                        // Unlike the deprecated `ares_query`, `ares_query_dnsrec` reports a
+                        // synchronous status. On failure the callback will not fire, so free
+                        // the handler here and fail the continuation to avoid a leak/hang.
+                        if status != ARES_SUCCESS {
+                            let pointer = handlerPointer.assumingMemoryBound(to: QueryReplyHandler.self)
+                            pointer.deinitialize(count: 1)
+                            pointer.deallocate()
+                            continuation.resume(throwing: AsyncDNSResolver.Error(cAresCode: CInt(status.rawValue)))
+                        }
                     }
                 }
             },
@@ -190,11 +211,6 @@ final class Ares: Sendable {
                 }
             }
         )
-    }
-
-    /// See `arpa/nameser.h`.
-    private enum DNSClass: CInt {
-        case IN = 1
     }
 }
 
@@ -219,31 +235,27 @@ extension Ares {
             self.locked_pollingTask?.cancel()
         }
 
-        init(channel: AresChannel, pollIntervalNanos: UInt64 = QueryProcessor.defaultPollInterval) {
+        init(
+            channel: AresChannel,
+            pollIntervalNanos: UInt64 = QueryProcessor.defaultPollInterval
+        ) {
             self.channel = channel
             self.pollIntervalNanos = pollIntervalNanos
         }
 
-        /// Asks c-ares for the set of socket descriptors we are waiting on for the `ares_channel`'s pending queries
-        /// then call `ares_process_fd` if any is ready for read and/or write.
-        /// c-ares returns up to `ARES_GETSOCK_MAXNUM` socket descriptors only. If more are in use (unlikely) they are not reported back.
+        /// Drives c-ares by calling `ares_process_fd` for each socket it is currently
+        /// waiting on. The set of sockets (and their read/write interest) is maintained
+        /// by the `sock_state_cb` in ``SocketRegistry`` rather than the deprecated
+        /// `ares_getsock`.
         func poll() {
-            var socks = [ares_socket_t](repeating: ares_socket_t(), count: Int(ARES_GETSOCK_MAXNUM))
+            let sockets = self.channel.socketRegistry.snapshot()
 
-            self.channel.withChannel { channel in
-                // Indicates what actions (i.e., read/write) to wait for on the different sockets
-                let bitmask = UInt32(ares_getsock(channel, &socks, ARES_GETSOCK_MAXNUM))
-
-                for (index, socket) in socks.enumerated() {
-                    let readableBit: UInt32 = 1 << UInt32(index)
-                    let readable = (bitmask & readableBit) != 0
-                    let writableBit = readableBit << UInt32(ARES_GETSOCK_MAXNUM)
-                    let writable = (bitmask & writableBit) != 0
-
-                    if readable || writable {
+            if !sockets.isEmpty {
+                self.channel.withChannel { channel in
+                    for entry in sockets {
                         // `ARES_SOCKET_BAD` instructs c-ares not to perform the action
-                        let readFD = readable ? socket : ARES_SOCKET_BAD
-                        let writeFD = writable ? socket : ARES_SOCKET_BAD
+                        let readFD = entry.readable ? entry.socket : ARES_SOCKET_BAD
+                        let writeFD = entry.writable ? entry.socket : ARES_SOCKET_BAD
                         ares_process_fd(channel, readFD, writeFD)
                     }
                 }
@@ -276,16 +288,16 @@ extension Ares {
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension Ares {
     class QueryReplyHandler {
-        private let _handler: (CInt, UnsafeMutablePointer<CUnsignedChar>?, CInt) -> Void
+        private let _handler: (ares_status_t, OpaquePointer?) -> Void
 
         init<Parser: AresQueryReplyParser>(parser: Parser, _ continuation: CheckedContinuation<Parser.Reply, Error>) {
-            self._handler = { status, buffer, length in
-                guard ares_status_t(status) == ARES_SUCCESS || ares_status_t(status) == ARES_ENODATA else {
-                    return continuation.resume(throwing: AsyncDNSResolver.Error(cAresCode: status))
+            self._handler = { status, dnsrec in
+                guard status == ARES_SUCCESS || status == ARES_ENODATA else {
+                    return continuation.resume(throwing: AsyncDNSResolver.Error(cAresCode: CInt(status.rawValue)))
                 }
 
                 do {
-                    let reply = try parser.parse(buffer: buffer, length: length)
+                    let reply = try parser.parse(dnsrec)
                     continuation.resume(returning: reply)
                 } catch {
                     continuation.resume(throwing: error)
@@ -293,8 +305,8 @@ extension Ares {
             }
         }
 
-        func handle(status: CInt, buffer: UnsafeMutablePointer<CUnsignedChar>?, length: CInt) {
-            self._handler(status, buffer, length)
+        func handle(status: ares_status_t, dnsrec: OpaquePointer?) {
+            self._handler(status, dnsrec)
         }
     }
 }
@@ -304,38 +316,46 @@ extension Ares {
 protocol AresQueryReplyParser {
     associatedtype Reply: Sendable
 
-    func parse(buffer: UnsafeMutablePointer<CUnsignedChar>?, length: CInt) throws -> Reply
+    /// Parse a reply from the (already parsed) DNS record c-ares delivers to the
+    /// query callback. The `dnsrec` pointer (`const ares_dns_record_t *`) is owned
+    /// by c-ares and is only valid for the duration of the call.
+    func parse(_ dnsrec: OpaquePointer?) throws -> Reply
+}
+
+/// Returns the answer-section resource records of the given type from `dnsrec`.
+/// The returned `ares_dns_rr_t` pointers are owned by c-ares and only valid while
+/// `dnsrec` is (i.e. for the duration of the callback).
+private func answerRecords(_ dnsrec: OpaquePointer?, ofType type: ares_dns_rec_type_t) -> [OpaquePointer] {
+    guard let dnsrec = dnsrec else { return [] }
+    let count = ares_dns_record_rr_cnt(dnsrec, ARES_SECTION_ANSWER)
+    var records = [OpaquePointer]()
+    for index in 0..<count {
+        guard let rr = ares_dns_record_rr_get_const(dnsrec, ARES_SECTION_ANSWER, index) else { continue }
+        // The answer section can contain other record types (e.g. CNAMEs); the old
+        // `ares_parse_*_reply` filtered internally, so we must filter here.
+        if ares_dns_rr_get_type(rr) == type {
+            records.append(rr)
+        }
+    }
+    return records
+}
+
+private func string(_ rr: OpaquePointer, _ key: ares_dns_rr_key_t) -> String? {
+    ares_dns_rr_get_str(rr, key).map { String(cString: $0) }
 }
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension Ares {
-    static let maxAddresses: Int = 32
-
     struct AQueryReplyParser: AresQueryReplyParser {
         static let instance = AQueryReplyParser()
 
-        func parse(buffer: UnsafeMutablePointer<CUnsignedChar>?, length: CInt) throws -> [ARecord] {
-            let addrttlsPointer = UnsafeMutablePointer<ares_addrttl>.allocate(capacity: Ares.maxAddresses)
-            defer { addrttlsPointer.deallocate() }
-            let naddrttlsPointer = UnsafeMutablePointer<CInt>.allocate(capacity: 1)
-            defer { naddrttlsPointer.deallocate() }
-
-            // Set a limit or else addrttl array won't be populated
-            naddrttlsPointer.pointee = CInt(Ares.maxAddresses)
-
-            let parseStatus = ares_parse_a_reply(buffer, length, nil, addrttlsPointer, naddrttlsPointer)
-
-            switch ares_status_t(parseStatus) {
-            case ARES_SUCCESS:
-                let records = Array(UnsafeBufferPointer(start: addrttlsPointer, count: Int(naddrttlsPointer.pointee)))
-                    .map { ARecord($0) }
-                return records
-
-            case ARES_ENODATA:
-                return []
-
-            default:
-                throw AsyncDNSResolver.Error(cAresCode: parseStatus, "failed to parse A query reply")
+        func parse(_ dnsrec: OpaquePointer?) throws -> [ARecord] {
+            answerRecords(dnsrec, ofType: ARES_REC_TYPE_A).compactMap { rr in
+                guard let addr = ares_dns_rr_get_addr(rr, ARES_RR_A_ADDR) else { return nil }
+                return ARecord(
+                    address: IPAddress.IPv4(addr.pointee),
+                    ttl: Int32(truncatingIfNeeded: ares_dns_rr_get_ttl(rr))
+                )
             }
         }
     }
@@ -343,28 +363,13 @@ extension Ares {
     struct AAAAQueryReplyParser: AresQueryReplyParser {
         static let instance = AAAAQueryReplyParser()
 
-        func parse(buffer: UnsafeMutablePointer<CUnsignedChar>?, length: CInt) throws -> [AAAARecord] {
-            let addrttlsPointer = UnsafeMutablePointer<ares_addr6ttl>.allocate(capacity: Ares.maxAddresses)
-            defer { addrttlsPointer.deallocate() }
-            let naddrttlsPointer = UnsafeMutablePointer<CInt>.allocate(capacity: 1)
-            defer { naddrttlsPointer.deallocate() }
-
-            // Set a limit or else addrttl array won't be populated
-            naddrttlsPointer.pointee = CInt(Ares.maxAddresses)
-
-            let parseStatus = ares_parse_aaaa_reply(buffer, length, nil, addrttlsPointer, naddrttlsPointer)
-
-            switch ares_status_t(parseStatus) {
-            case ARES_SUCCESS:
-                let records = Array(UnsafeBufferPointer(start: addrttlsPointer, count: Int(naddrttlsPointer.pointee)))
-                    .map { AAAARecord($0) }
-                return records
-
-            case ARES_ENODATA:
-                return []
-
-            default:
-                throw AsyncDNSResolver.Error(cAresCode: parseStatus, "failed to parse AAAA query reply")
+        func parse(_ dnsrec: OpaquePointer?) throws -> [AAAARecord] {
+            answerRecords(dnsrec, ofType: ARES_REC_TYPE_AAAA).compactMap { rr in
+                guard let addr = ares_dns_rr_get_addr6(rr, ARES_RR_AAAA_ADDR) else { return nil }
+                return AAAARecord(
+                    address: IPAddress.IPv6(addr.pointee),
+                    ttl: Int32(truncatingIfNeeded: ares_dns_rr_get_ttl(rr))
+                )
             }
         }
     }
@@ -372,151 +377,61 @@ extension Ares {
     struct NSQueryReplyParser: AresQueryReplyParser {
         static let instance = NSQueryReplyParser()
 
-        func parse(buffer: UnsafeMutablePointer<CUnsignedChar>?, length: CInt) throws -> NSRecord {
-            let hostentPtrPtr = UnsafeMutablePointer<UnsafeMutablePointer<hostent>?>.allocate(capacity: 1)
-            defer { hostentPtrPtr.deallocate() }
-
-            let parseStatus = ares_parse_ns_reply(buffer, length, hostentPtrPtr)
-
-            switch ares_status_t(parseStatus) {
-            case ARES_SUCCESS:
-                guard let hostent = hostentPtrPtr.pointee?.pointee else {
-                    return NSRecord(nameservers: [])
-                }
-
-                let nameServers = toStringArray(hostent.h_aliases)
-                return NSRecord(nameservers: nameServers ?? [])
-
-            case ARES_ENODATA:
-                return NSRecord(nameservers: [])
-
-            default:
-                throw AsyncDNSResolver.Error(cAresCode: parseStatus, "failed to parse NS query reply")
+        func parse(_ dnsrec: OpaquePointer?) throws -> NSRecord {
+            let nameservers = answerRecords(dnsrec, ofType: ARES_REC_TYPE_NS).compactMap {
+                string($0, ARES_RR_NS_NSDNAME)
             }
+            return NSRecord(nameservers: nameservers)
         }
     }
 
     struct CNAMEQueryReplyParser: AresQueryReplyParser {
         static let instance = CNAMEQueryReplyParser()
 
-        func parse(buffer: UnsafeMutablePointer<CUnsignedChar>?, length: CInt) throws -> String? {
-            let hostentPtrPtr = UnsafeMutablePointer<UnsafeMutablePointer<hostent>?>.allocate(capacity: 1)
-            defer { hostentPtrPtr.deallocate() }
-
-            let parseStatus = ares_parse_a_reply(buffer, length, hostentPtrPtr, nil, nil)
-
-            switch ares_status_t(parseStatus) {
-            case ARES_SUCCESS:
-                guard let hostent = hostentPtrPtr.pointee?.pointee else {
-                    return nil
-                }
-                return String(cString: hostent.h_name)
-
-            case ARES_ENODATA:
-                return nil
-            default:
-                throw AsyncDNSResolver.Error(cAresCode: parseStatus, "failed to parse CNAME query reply")
-            }
+        func parse(_ dnsrec: OpaquePointer?) throws -> String? {
+            answerRecords(dnsrec, ofType: ARES_REC_TYPE_CNAME).lazy.compactMap {
+                string($0, ARES_RR_CNAME_CNAME)
+            }.first
         }
     }
 
     struct SOAQueryReplyParser: AresQueryReplyParser {
         static let instance = SOAQueryReplyParser()
 
-        func parse(buffer: UnsafeMutablePointer<CUnsignedChar>?, length: CInt) throws -> SOARecord? {
-            let soaReplyPtrPtr = UnsafeMutablePointer<UnsafeMutablePointer<ares_soa_reply>?>.allocate(capacity: 1)
-            defer { soaReplyPtrPtr.deallocate() }
-
-            let parseStatus = ares_parse_soa_reply(buffer, length, soaReplyPtrPtr)
-            switch ares_status_t(parseStatus) {
-            case ARES_SUCCESS:
-                guard let soaReply = soaReplyPtrPtr.pointee?.pointee else {
-                    return nil
-                }
-
-                return SOARecord(
-                    mname: soaReply.nsname.map { String(cString: $0) },
-                    rname: soaReply.hostmaster.map { String(cString: $0) },
-                    serial: soaReply.serial,
-                    refresh: soaReply.refresh,
-                    retry: soaReply.retry,
-                    expire: soaReply.expire,
-                    ttl: soaReply.minttl
-                )
-
-            case ARES_ENODATA:
+        func parse(_ dnsrec: OpaquePointer?) throws -> SOARecord? {
+            guard let rr = answerRecords(dnsrec, ofType: ARES_REC_TYPE_SOA).first else {
                 return nil
-
-            default:
-                throw AsyncDNSResolver.Error(cAresCode: parseStatus, "failed to parse SOA query reply")
             }
+            return SOARecord(
+                mname: string(rr, ARES_RR_SOA_MNAME),
+                rname: string(rr, ARES_RR_SOA_RNAME),
+                serial: ares_dns_rr_get_u32(rr, ARES_RR_SOA_SERIAL),
+                refresh: ares_dns_rr_get_u32(rr, ARES_RR_SOA_REFRESH),
+                retry: ares_dns_rr_get_u32(rr, ARES_RR_SOA_RETRY),
+                expire: ares_dns_rr_get_u32(rr, ARES_RR_SOA_EXPIRE),
+                ttl: ares_dns_rr_get_u32(rr, ARES_RR_SOA_MINIMUM)
+            )
         }
     }
 
     struct PTRQueryReplyParser: AresQueryReplyParser {
         static let instance = PTRQueryReplyParser()
 
-        func parse(buffer: UnsafeMutablePointer<CUnsignedChar>?, length: CInt) throws -> PTRRecord {
-            let dummyAddrPointer = UnsafeMutablePointer<CChar>.allocate(capacity: 1)
-            defer { dummyAddrPointer.deallocate() }
-            let hostentPtrPtr = UnsafeMutablePointer<UnsafeMutablePointer<hostent>?>.allocate(capacity: 1)
-            defer { hostentPtrPtr.deallocate() }
-
-            let parseStatus = ares_parse_ptr_reply(
-                buffer,
-                length,
-                dummyAddrPointer,
-                INET_ADDRSTRLEN,
-                AF_INET,
-                hostentPtrPtr
-            )
-
-            switch ares_status_t(parseStatus) {
-            case ARES_SUCCESS:
-                guard let hostent = hostentPtrPtr.pointee?.pointee else {
-                    return PTRRecord(names: [])
-                }
-
-                let hostnames = toStringArray(hostent.h_aliases)
-                return PTRRecord(names: hostnames ?? [])
-
-            case ARES_ENODATA:
-                return PTRRecord(names: [])
-
-            default:
-                throw AsyncDNSResolver.Error(cAresCode: parseStatus, "failed to parse PTR query record")
+        func parse(_ dnsrec: OpaquePointer?) throws -> PTRRecord {
+            let names = answerRecords(dnsrec, ofType: ARES_REC_TYPE_PTR).compactMap {
+                string($0, ARES_RR_PTR_DNAME)
             }
+            return PTRRecord(names: names)
         }
     }
 
     struct MXQueryReplyParser: AresQueryReplyParser {
         static let instance = MXQueryReplyParser()
 
-        func parse(buffer: UnsafeMutablePointer<CUnsignedChar>?, length: CInt) throws -> [MXRecord] {
-            let mxsPointer = UnsafeMutablePointer<UnsafeMutablePointer<ares_mx_reply>?>.allocate(capacity: 1)
-            defer { mxsPointer.deallocate() }
-
-            let parseStatus = ares_parse_mx_reply(buffer, length, mxsPointer)
-            switch ares_status_t(parseStatus) {
-            case ARES_SUCCESS:
-                var mxRecords = [MXRecord]()
-                var mxRecordOptional = mxsPointer.pointee?.pointee
-                while let mxRecord = mxRecordOptional {
-                    mxRecords.append(
-                        MXRecord(
-                            host: String(cString: mxRecord.host),
-                            priority: mxRecord.priority
-                        )
-                    )
-                    mxRecordOptional = mxRecord.next?.pointee
-                }
-                return mxRecords
-
-            case ARES_ENODATA:
-                return []
-
-            default:
-                throw AsyncDNSResolver.Error(cAresCode: parseStatus, "failed to parse MX query record")
+        func parse(_ dnsrec: OpaquePointer?) throws -> [MXRecord] {
+            answerRecords(dnsrec, ofType: ARES_REC_TYPE_MX).compactMap { rr in
+                guard let host = string(rr, ARES_RR_MX_EXCHANGE) else { return nil }
+                return MXRecord(host: host, priority: ares_dns_rr_get_u16(rr, ARES_RR_MX_PREFERENCE))
             }
         }
     }
@@ -524,66 +439,34 @@ extension Ares {
     struct TXTQueryReplyParser: AresQueryReplyParser {
         static let instance = TXTQueryReplyParser()
 
-        func parse(buffer: UnsafeMutablePointer<CUnsignedChar>?, length: CInt) throws -> [TXTRecord] {
-            let txtsPointer = UnsafeMutablePointer<UnsafeMutablePointer<ares_txt_reply>?>.allocate(capacity: 1)
-            defer { txtsPointer.deallocate() }
-
-            let parseStatus = ares_parse_txt_reply(buffer, length, txtsPointer)
-
-            switch ares_status_t(parseStatus) {
-            case ARES_SUCCESS:
-                var txtRecords = [TXTRecord]()
-                var txtRecordOptional = txtsPointer.pointee?.pointee
-                while let txtRecord = txtRecordOptional {
-                    txtRecords.append(
-                        TXTRecord(
-                            txt: String(cString: txtRecord.txt)
-                        )
-                    )
-                    txtRecordOptional = txtRecord.next?.pointee
+        func parse(_ dnsrec: OpaquePointer?) throws -> [TXTRecord] {
+            var records = [TXTRecord]()
+            for rr in answerRecords(dnsrec, ofType: ARES_REC_TYPE_TXT) {
+                // TXT data is an array of binary strings; emit one record per segment.
+                let segments = ares_dns_rr_get_abin_cnt(rr, ARES_RR_TXT_DATA)
+                for index in 0..<segments {
+                    var length: size_t = 0
+                    guard let bytes = ares_dns_rr_get_abin(rr, ARES_RR_TXT_DATA, index, &length) else { continue }
+                    let txt = String(decoding: UnsafeBufferPointer(start: bytes, count: length), as: UTF8.self)
+                    records.append(TXTRecord(txt: txt))
                 }
-                return txtRecords
-
-            case ARES_ENODATA:
-                return []
-
-            default:
-                throw AsyncDNSResolver.Error(cAresCode: parseStatus, "failed to parse TXT query reply")
             }
+            return records
         }
     }
 
     struct SRVQueryReplyParser: AresQueryReplyParser {
         static let instance = SRVQueryReplyParser()
 
-        func parse(buffer: UnsafeMutablePointer<CUnsignedChar>?, length: CInt) throws -> [SRVRecord] {
-            let replyPointer = UnsafeMutablePointer<UnsafeMutablePointer<ares_srv_reply>?>.allocate(capacity: 1)
-            defer { replyPointer.deallocate() }
-
-            let parseStatus = ares_parse_srv_reply(buffer, length, replyPointer)
-
-            switch ares_status_t(parseStatus) {
-            case ARES_SUCCESS:
-                var srvRecords = [SRVRecord]()
-                var srvRecordOptional = replyPointer.pointee?.pointee
-                while let srvRecord = srvRecordOptional {
-                    srvRecords.append(
-                        SRVRecord(
-                            host: String(cString: srvRecord.host),
-                            port: srvRecord.port,
-                            weight: srvRecord.weight,
-                            priority: srvRecord.priority
-                        )
-                    )
-                    srvRecordOptional = srvRecord.next?.pointee
-                }
-                return srvRecords
-
-            case ARES_ENODATA:
-                return []
-
-            default:
-                throw AsyncDNSResolver.Error(cAresCode: parseStatus, "failed to parse SRV query reply")
+        func parse(_ dnsrec: OpaquePointer?) throws -> [SRVRecord] {
+            answerRecords(dnsrec, ofType: ARES_REC_TYPE_SRV).compactMap { rr in
+                guard let host = string(rr, ARES_RR_SRV_TARGET) else { return nil }
+                return SRVRecord(
+                    host: host,
+                    port: ares_dns_rr_get_u16(rr, ARES_RR_SRV_PORT),
+                    weight: ares_dns_rr_get_u16(rr, ARES_RR_SRV_WEIGHT),
+                    priority: ares_dns_rr_get_u16(rr, ARES_RR_SRV_PRIORITY)
+                )
             }
         }
     }
@@ -591,56 +474,22 @@ extension Ares {
     struct NAPTRQueryReplyParser: AresQueryReplyParser {
         static let instance = NAPTRQueryReplyParser()
 
-        func parse(buffer: UnsafeMutablePointer<CUnsignedChar>?, length: CInt) throws -> [NAPTRRecord] {
-            let naptrsPointer = UnsafeMutablePointer<UnsafeMutablePointer<ares_naptr_reply>?>.allocate(capacity: 1)
-            defer { naptrsPointer.deallocate() }
-
-            let parseStatus = ares_parse_naptr_reply(buffer, length, naptrsPointer)
-
-            switch ares_status_t(parseStatus) {
-            case ARES_SUCCESS:
-                var naptrRecords = [NAPTRRecord]()
-                var naptrRecordOptional = naptrsPointer.pointee?.pointee
-                while let naptrRecord = naptrRecordOptional {
-                    naptrRecords.append(
-                        NAPTRRecord(
-                            flags: String(cString: naptrRecord.flags),
-                            service: String(cString: naptrRecord.service),
-                            regExp: String(cString: naptrRecord.regexp),
-                            replacement: String(cString: naptrRecord.replacement),
-                            order: naptrRecord.order,
-                            preference: naptrRecord.preference
-                        )
-                    )
-                    naptrRecordOptional = naptrRecord.next?.pointee
-                }
-                return naptrRecords
-
-            case ARES_ENODATA:
-                return []
-
-            default:
-                throw AsyncDNSResolver.Error(cAresCode: parseStatus, "failed to parse NAPTR query reply")
+        func parse(_ dnsrec: OpaquePointer?) throws -> [NAPTRRecord] {
+            answerRecords(dnsrec, ofType: ARES_REC_TYPE_NAPTR).map { rr in
+                NAPTRRecord(
+                    flags: string(rr, ARES_RR_NAPTR_FLAGS),
+                    service: string(rr, ARES_RR_NAPTR_SERVICES),
+                    regExp: string(rr, ARES_RR_NAPTR_REGEXP),
+                    replacement: string(rr, ARES_RR_NAPTR_REPLACEMENT) ?? "",
+                    order: ares_dns_rr_get_u16(rr, ARES_RR_NAPTR_ORDER),
+                    preference: ares_dns_rr_get_u16(rr, ARES_RR_NAPTR_PREFERENCE)
+                )
             }
         }
     }
 }
 
 // MARK: - helpers
-
-private func toStringArray(_ arrayPointer: UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>?) -> [String]? {
-    guard let arrayPointer = arrayPointer else {
-        return nil
-    }
-
-    var result = [String]()
-    var stringPointer = arrayPointer
-    while let ptr = stringPointer.pointee {
-        result.append(String(cString: ptr))
-        stringPointer = stringPointer.advanced(by: 1)
-    }
-    return result
-}
 
 extension IPAddress.IPv4 {
     init(_ address: in_addr) {
@@ -655,20 +504,6 @@ extension IPAddress.IPv6 {
         var address = address
         let addressString = sys_inet_ntop(family: AF_INET6, bytes: &address, length: Int(INET6_ADDRSTRLEN)) ?? ""
         self = IPAddress.IPv6(address: addressString)
-    }
-}
-
-extension ARecord {
-    init(_ addrttl: ares_addrttl) {
-        self.address = IPAddress.IPv4(addrttl.ipaddr)
-        self.ttl = addrttl.ttl
-    }
-}
-
-extension AAAARecord {
-    init(_ addrttl: ares_addr6ttl) {
-        self.address = IPAddress.IPv6(addrttl.ip6addr)
-        self.ttl = addrttl.ttl
     }
 }
 

--- a/Sources/AsyncDNSResolver/c-ares/DNSResolver_c-ares.swift
+++ b/Sources/AsyncDNSResolver/c-ares/DNSResolver_c-ares.swift
@@ -195,7 +195,8 @@ final class Ares: Sendable {
                         )
                         // Unlike the deprecated `ares_query`, `ares_query_dnsrec` reports a
                         // synchronous status. On failure the callback will not fire, so free
-                        // the handler here and fail the continuation to avoid a leak/hang.
+                        // the handler here and fail the continuation, otherwise it would leak
+                        // and the caller would await forever.
                         if status != ARES_SUCCESS {
                             let pointer = handlerPointer.assumingMemoryBound(to: QueryReplyHandler.self)
                             pointer.deinitialize(count: 1)

--- a/Sources/AsyncDNSResolver/c-ares/Errors_c-ares.swift
+++ b/Sources/AsyncDNSResolver/c-ares/Errors_c-ares.swift
@@ -14,6 +14,15 @@
 
 import CAsyncDNSResolver
 
+extension ares_status_t {
+    /// Bridge a c-ares `CInt` status code to the strongly-typed `ares_status_t`
+    /// enum. As of c-ares 1.20+ the `ARES_*` status constants are members of the
+    /// `ares_status_t` enum, while the legacy parse and init APIs still return `int`.
+    init(_ status: Int32) {
+        self.init(rawValue: ares_status_t.RawValue(status))
+    }
+}
+
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension AsyncDNSResolver.Error {
     /// Create an ``AsyncDNSResolver/AsyncDNSResolver/Error`` from c-ares error code.
@@ -21,7 +30,7 @@ extension AsyncDNSResolver.Error {
         self.message = description
         self.source = CAresError(code: Int(cAresCode))
 
-        switch cAresCode {
+        switch ares_status_t(cAresCode) {
         case ARES_EFORMERR, ARES_EBADQUERY, ARES_EBADNAME, ARES_EBADFAMILY, ARES_EBADFLAGS:
             self.code = .badQuery
         case ARES_EBADRESP:

--- a/Sources/CAsyncDNSResolver/include/ares_build.h
+++ b/Sources/CAsyncDNSResolver/include/ares_build.h
@@ -23,10 +23,12 @@
  * for C-Ares */
 #define CARES_HAVE_SYS_TYPES_H
 #define CARES_HAVE_SYS_SOCKET_H
+#define CARES_HAVE_SYS_SELECT_H
 /* #undef CARES_HAVE_WINDOWS_H */
 /* #undef CARES_HAVE_WS2TCPIP_H */
 /* #undef CARES_HAVE_WINSOCK2_H */
-/* #undef CARES_HAVE_WINDOWS_H */
+#define CARES_HAVE_ARPA_NAMESER_H
+#define CARES_HAVE_ARPA_NAMESER_COMPAT_H
 
 #ifdef CARES_HAVE_SYS_TYPES_H
 #  include <sys/types.h>
@@ -34,6 +36,10 @@
 
 #ifdef CARES_HAVE_SYS_SOCKET_H
 #  include <sys/socket.h>
+#endif
+
+#ifdef CARES_HAVE_SYS_SELECT_H
+#  include <sys/select.h>
 #endif
 
 #ifdef CARES_HAVE_WINSOCK2_H
@@ -47,9 +53,5 @@
 #ifdef CARES_HAVE_WINDOWS_H
 #  include <windows.h>
 #endif
-
-
-typedef CARES_TYPEOF_ARES_SOCKLEN_T ares_socklen_t;
-typedef CARES_TYPEOF_ARES_SSIZE_T ares_ssize_t;
 
 #endif /* __CARES_BUILD_H */

--- a/Sources/CAsyncDNSResolver/include/ares_config.h
+++ b/Sources/CAsyncDNSResolver/include/ares_config.h
@@ -12,28 +12,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-/* Generated from ares_config.h.cmake*/
+/* Generated from ares_config.h.cmake */
 
 /* Define if building universal (internal helper macro) */
 #undef AC_APPLE_UNIVERSAL_BUILD
 
-/* define this if ares is built for a big endian system */
-#undef ARES_BIG_ENDIAN
-
-/* when building as static part of libcurl */
-#undef BUILDING_LIBCURL
-
-/* Defined for build that exposes internal static functions for testing. */
-#undef CARES_EXPOSE_STATICS
-
 /* Defined for build with symbol hiding. */
-#undef CARES_SYMBOL_HIDING
-
-/* Definition to make a library symbol externally visible. */
-#undef CARES_SYMBOL_SCOPE_EXTERN
+/* #undef CARES_SYMBOL_HIDING */
 
 /* Use resolver library to configure cares */
-#undef CARES_USE_LIBRESOLV
+/* #undef CARES_USE_LIBRESOLV */
 
 /* if a /etc/inet dir is being used */
 #undef ETC_INET
@@ -63,28 +51,22 @@
 #define GETSERVBYNAME_R_ARGS 
 
 /* Define to 1 if you have AF_INET6. */
-#define HAVE_AF_INET6
+#define HAVE_AF_INET6 1
 
 /* Define to 1 if you have the <arpa/inet.h> header file. */
-#define HAVE_ARPA_INET_H
+#define HAVE_ARPA_INET_H 1
 
 /* Define to 1 if you have the <arpa/nameser_compat.h> header file. */
-#define HAVE_ARPA_NAMESER_COMPAT_H
+#define HAVE_ARPA_NAMESER_COMPAT_H 1
 
 /* Define to 1 if you have the <arpa/nameser.h> header file. */
-#define HAVE_ARPA_NAMESER_H
+#define HAVE_ARPA_NAMESER_H 1
 
 /* Define to 1 if you have the <assert.h> header file. */
-#define HAVE_ASSERT_H
-
-/* Define to 1 if you have the `bitncmp' function. */
-/* #undef HAVE_BITNCMP */
-
-/* Define to 1 if bool is an available type. */
-#define HAVE_BOOL_T
+#define HAVE_ASSERT_H 1
 
 /* Define to 1 if you have the clock_gettime function and monotonic timer. */
-#define HAVE_CLOCK_GETTIME_MONOTONIC
+#define HAVE_CLOCK_GETTIME_MONOTONIC 1
 
 /* Define to 1 if you have the closesocket function. */
 /* #undef HAVE_CLOSESOCKET */
@@ -93,49 +75,70 @@
 /* #undef HAVE_CLOSESOCKET_CAMEL */
 
 /* Define to 1 if you have the connect function. */
-#define HAVE_CONNECT
+#define HAVE_CONNECT 1
+
+/* Define to 1 if you have the connectx function. */
+#define HAVE_CONNECTX 1
 
 /* define if the compiler supports basic C++11 syntax */
 /* #undef HAVE_CXX11 */
 
 /* Define to 1 if you have the <dlfcn.h> header file. */
-#define HAVE_DLFCN_H
+#define HAVE_DLFCN_H 1
 
 /* Define to 1 if you have the <errno.h> header file. */
-#define HAVE_ERRNO_H
+#define HAVE_ERRNO_H 1
+
+/* Define to 1 if you have the <poll.h> header file. */
+#define HAVE_POLL_H 1
+
+/* Define to 1 if you have the memmem function. */
+#define HAVE_MEMMEM 1
+
+/* Define to 1 if you have the poll function. */
+#define HAVE_POLL 1
+
+/* Define to 1 if you have the pipe function. */
+#define HAVE_PIPE 1
+
+/* Define to 1 if you have the pipe2 function. */
+/* #undef HAVE_PIPE2 */
+
+/* Define to 1 if you have the kqueue function. */
+#define HAVE_KQUEUE 1
+
+/* Define to 1 if you have the epoll{_create,ctl,wait} functions. */
+/* #undef HAVE_EPOLL */
 
 /* Define to 1 if you have the fcntl function. */
-#define HAVE_FCNTL
+#define HAVE_FCNTL 1
 
 /* Define to 1 if you have the <fcntl.h> header file. */
-#define HAVE_FCNTL_H
+#define HAVE_FCNTL_H 1
 
 /* Define to 1 if you have a working fcntl O_NONBLOCK function. */
-#define HAVE_FCNTL_O_NONBLOCK
+#define HAVE_FCNTL_O_NONBLOCK 1
 
 /* Define to 1 if you have the freeaddrinfo function. */
-#define HAVE_FREEADDRINFO
+#define HAVE_FREEADDRINFO 1
 
 /* Define to 1 if you have a working getaddrinfo function. */
-#define HAVE_GETADDRINFO
+#define HAVE_GETADDRINFO 1
 
 /* Define to 1 if the getaddrinfo function is threadsafe. */
-#define HAVE_GETADDRINFO_THREADSAFE
+#define HAVE_GETADDRINFO_THREADSAFE 1
 
 /* Define to 1 if you have the getenv function. */
-#define HAVE_GETENV
-
-/* Define to 1 if you have the gethostbyaddr function. */
-#define HAVE_GETHOSTBYADDR
-
-/* Define to 1 if you have the gethostbyname function. */
-#define HAVE_GETHOSTBYNAME
+#define HAVE_GETENV 1
 
 /* Define to 1 if you have the gethostname function. */
-#define HAVE_GETHOSTNAME
+#define HAVE_GETHOSTNAME 1
 
 /* Define to 1 if you have the getnameinfo function. */
-#define HAVE_GETNAMEINFO
+#define HAVE_GETNAMEINFO 1
+
+/* Define to 1 if you have the getrandom function. */
+/* #undef HAVE_GETRANDOM */
 
 /* Define to 1 if you have the getservbyport_r function. */
 /* #undef HAVE_GETSERVBYPORT_R */
@@ -144,25 +147,43 @@
 /* #undef HAVE_GETSERVBYNAME_R */
 
 /* Define to 1 if you have the `gettimeofday' function. */
-#define HAVE_GETTIMEOFDAY
+#define HAVE_GETTIMEOFDAY 1
 
 /* Define to 1 if you have the `if_indextoname' function. */
-#define HAVE_IF_INDEXTONAME
+#define HAVE_IF_INDEXTONAME 1
+
+/* Define to 1 if you have the `if_nametoindex' function. */
+#define HAVE_IF_NAMETOINDEX 1
+
+/* Define to 1 if you have the `GetBestRoute2' function. */
+/* #undef HAVE_GETBESTROUTE2 */
+
+/* Define to 1 if you have the `ConvertInterfaceIndexToLuid' function. */
+/* #undef HAVE_CONVERTINTERFACEINDEXTOLUID */
+
+/* Define to 1 if you have the `ConvertInterfaceLuidToNameA' function. */
+/* #undef HAVE_CONVERTINTERFACELUIDTONAMEA */
+
+/* Define to 1 if you have the `NotifyIpInterfaceChange' function. */
+/* #undef HAVE_NOTIFYIPINTERFACECHANGE */
+
+/* Define to 1 if you have the `RegisterWaitForSingleObject' function. */
+/* #undef HAVE_REGISTERWAITFORSINGLEOBJECT */
 
 /* Define to 1 if you have a IPv6 capable working inet_net_pton function. */
-/* #undef HAVE_INET_NET_PTON */
+#define HAVE_INET_NET_PTON 1
 
 /* Define to 1 if you have a IPv6 capable working inet_ntop function. */
-#define HAVE_INET_NTOP
+#define HAVE_INET_NTOP 1
 
 /* Define to 1 if you have a IPv6 capable working inet_pton function. */
-#define HAVE_INET_PTON
+#define HAVE_INET_PTON 1
 
 /* Define to 1 if you have the <inttypes.h> header file. */
-#define HAVE_INTTYPES_H
+#define HAVE_INTTYPES_H 1
 
 /* Define to 1 if you have the ioctl function. */
-#define HAVE_IOCTL
+#define HAVE_IOCTL 1
 
 /* Define to 1 if you have the ioctlsocket function. */
 /* #undef HAVE_IOCTLSOCKET */
@@ -178,109 +199,118 @@
 /* #undef HAVE_IOCTLSOCKET_FIONBIO */
 
 /* Define to 1 if you have a working ioctl FIONBIO function. */
-#define HAVE_IOCTL_FIONBIO
+#define HAVE_IOCTL_FIONBIO 1
 
 /* Define to 1 if you have a working ioctl SIOCGIFADDR function. */
-#define HAVE_IOCTL_SIOCGIFADDR
+#define HAVE_IOCTL_SIOCGIFADDR 1
 
 /* Define to 1 if you have the `resolve' library (-lresolve). */
-#undef HAVE_LIBRESOLV
+#define HAVE_LIBRESOLV 1
+
+/* Define to 1 if you have iphlpapi.h */
+/* #undef HAVE_IPHLPAPI_H */
+
+/* Define to 1 if you have netioapi.h */
+/* #undef HAVE_NETIOAPI_H */
 
 /* Define to 1 if you have the <limits.h> header file. */
-#define HAVE_LIMITS_H
-
-/* if your compiler supports LL */
-#define HAVE_LL
+#define HAVE_LIMITS_H 1
 
 /* Define to 1 if the compiler supports the 'long long' data type. */
-#define HAVE_LONGLONG
+#define HAVE_LONGLONG 1
 
 /* Define to 1 if you have the malloc.h header file. */
 /* #undef HAVE_MALLOC_H */
 
 /* Define to 1 if you have the memory.h header file. */
-#define HAVE_MEMORY_H
+#define HAVE_MEMORY_H 1
+
+/* Define to 1 if you have the AvailabilityMacros.h header file. */
+#define HAVE_AVAILABILITYMACROS_H 1
 
 /* Define to 1 if you have the MSG_NOSIGNAL flag. */
-/* #undef HAVE_MSG_NOSIGNAL */
+#define HAVE_MSG_NOSIGNAL 1
 
 /* Define to 1 if you have the <netdb.h> header file. */
-#define HAVE_NETDB_H
+#define HAVE_NETDB_H 1
 
 /* Define to 1 if you have the <netinet/in.h> header file. */
-#define HAVE_NETINET_IN_H
+#define HAVE_NETINET_IN_H 1
+
+/* Define to 1 if you have the <netinet6/in6.h> header file. */
+/* #undef HAVE_NETINET6_IN6_H */
 
 /* Define to 1 if you have the <netinet/tcp.h> header file. */
-#define HAVE_NETINET_TCP_H
+#define HAVE_NETINET_TCP_H 1
 
 /* Define to 1 if you have the <net/if.h> header file. */
-#define HAVE_NET_IF_H
+#define HAVE_NET_IF_H 1
 
 /* Define to 1 if you have PF_INET6. */
-#define HAVE_PF_INET6
+#define HAVE_PF_INET6 1
 
 /* Define to 1 if you have the recv function. */
-#define HAVE_RECV
+#define HAVE_RECV 1
 
 /* Define to 1 if you have the recvfrom function. */
-#define HAVE_RECVFROM
+#define HAVE_RECVFROM 1
 
 /* Define to 1 if you have the send function. */
-#define HAVE_SEND
+#define HAVE_SEND 1
+
+/* Define to 1 if you have the sendto function. */
+#define HAVE_SENDTO 1
 
 /* Define to 1 if you have the setsockopt function. */
-#define HAVE_SETSOCKOPT
+#define HAVE_SETSOCKOPT 1
 
 /* Define to 1 if you have a working setsockopt SO_NONBLOCK function. */
 /* #undef HAVE_SETSOCKOPT_SO_NONBLOCK */
 
 /* Define to 1 if you have the <signal.h> header file. */
-#define HAVE_SIGNAL_H
+#define HAVE_SIGNAL_H 1
 
-/* Define to 1 if sig_atomic_t is an available typedef. */
-#define HAVE_SIG_ATOMIC_T
-
-/* Define to 1 if sig_atomic_t is already defined as volatile. */
-/* #undef HAVE_SIG_ATOMIC_T_VOLATILE */
+/* Define to 1 if you have the strnlen function. */
+#define HAVE_STRNLEN 1
 
 /* Define to 1 if your struct sockaddr_in6 has sin6_scope_id. */
-#define HAVE_SOCKADDR_IN6_SIN6_SCOPE_ID
+#define HAVE_STRUCT_SOCKADDR_IN6_SIN6_SCOPE_ID 1
 
 /* Define to 1 if you have the socket function. */
-#define HAVE_SOCKET
+#define HAVE_SOCKET 1
 
 /* Define to 1 if you have the <socket.h> header file. */
 /* #undef HAVE_SOCKET_H */
 
 /* Define to 1 if you have the <stdbool.h> header file. */
-#define HAVE_STDBOOL_H
+#define HAVE_STDBOOL_H 1
 
 /* Define to 1 if you have the <stdint.h> header file. */
-#define HAVE_STDINT_H
+#define HAVE_STDINT_H 1
 
 /* Define to 1 if you have the <stdlib.h> header file. */
-#define HAVE_STDLIB_H
+#define HAVE_STDLIB_H 1
 
 /* Define to 1 if you have the strcasecmp function. */
-#define HAVE_STRCASECMP
+#define HAVE_STRCASECMP 1
 
 /* Define to 1 if you have the strcmpi function. */
 /* #undef HAVE_STRCMPI */
 
 /* Define to 1 if you have the strdup function. */
-#define HAVE_STRDUP
+#define HAVE_STRDUP 1
 
 /* Define to 1 if you have the stricmp function. */
 /* #undef HAVE_STRICMP */
 
 /* Define to 1 if you have the <strings.h> header file. */
-#define HAVE_STRINGS_H
+#define HAVE_STRINGS_H 1
 
 /* Define to 1 if you have the <string.h> header file. */
-#define HAVE_STRING_H
+#define HAVE_STRING_H 1
 
 /* Define to 1 if you have the strncasecmp function. */
-#define HAVE_STRNCASECMP
+#define HAVE_STRNCASECMP 1
 
 /* Define to 1 if you have the strncmpi function. */
 /* #undef HAVE_STRNCMPI */
@@ -292,49 +322,61 @@
 /* #undef HAVE_STROPTS_H */
 
 /* Define to 1 if you have struct addrinfo. */
-#define HAVE_STRUCT_ADDRINFO
+#define HAVE_STRUCT_ADDRINFO 1
 
 /* Define to 1 if you have struct in6_addr. */
-#define HAVE_STRUCT_IN6_ADDR
+#define HAVE_STRUCT_IN6_ADDR 1
 
 /* Define to 1 if you have struct sockaddr_in6. */
-#define HAVE_STRUCT_SOCKADDR_IN6
+#define HAVE_STRUCT_SOCKADDR_IN6 1
 
 /* if struct sockaddr_storage is defined */
-#define HAVE_STRUCT_SOCKADDR_STORAGE
+#define HAVE_STRUCT_SOCKADDR_STORAGE 1
 
 /* Define to 1 if you have the timeval struct. */
-#define HAVE_STRUCT_TIMEVAL
+#define HAVE_STRUCT_TIMEVAL 1
 
 /* Define to 1 if you have the <sys/ioctl.h> header file. */
-#define HAVE_SYS_IOCTL_H
+#define HAVE_SYS_IOCTL_H 1
 
 /* Define to 1 if you have the <sys/param.h> header file. */
-#define HAVE_SYS_PARAM_H
+#define HAVE_SYS_PARAM_H 1
+
+/* Define to 1 if you have the <sys/random.h> header file. */
+#define HAVE_SYS_RANDOM_H 1
+
+/* Define to 1 if you have the <sys/event.h> header file. */
+#define HAVE_SYS_EVENT_H 1
+
+/* Define to 1 if you have the <sys/epoll.h> header file. */
+/* #undef HAVE_SYS_EPOLL_H */
 
 /* Define to 1 if you have the <sys/select.h> header file. */
-#define HAVE_SYS_SELECT_H
+#define HAVE_SYS_SELECT_H 1
 
 /* Define to 1 if you have the <sys/socket.h> header file. */
-#define HAVE_SYS_SOCKET_H
+#define HAVE_SYS_SOCKET_H 1
 
 /* Define to 1 if you have the <sys/stat.h> header file. */
-#define HAVE_SYS_STAT_H
+#define HAVE_SYS_STAT_H 1
 
 /* Define to 1 if you have the <sys/time.h> header file. */
-#define HAVE_SYS_TIME_H
+#define HAVE_SYS_TIME_H 1
 
 /* Define to 1 if you have the <sys/types.h> header file. */
-#define HAVE_SYS_TYPES_H
+#define HAVE_SYS_TYPES_H 1
 
 /* Define to 1 if you have the <sys/uio.h> header file. */
-#define HAVE_SYS_UIO_H
+#define HAVE_SYS_UIO_H 1
 
 /* Define to 1 if you have the <time.h> header file. */
-#define HAVE_TIME_H
+#define HAVE_TIME_H 1
+
+/* Define to 1 if you have the <ifaddrs.h> header file. */
+#define HAVE_IFADDRS_H 1
 
 /* Define to 1 if you have the <unistd.h> header file. */
-#define HAVE_UNISTD_H
+#define HAVE_UNISTD_H 1
 
 /* Define to 1 if you have the windows.h header file. */
 /* #undef HAVE_WINDOWS_H */
@@ -345,8 +387,20 @@
 /* Define to 1 if you have the winsock.h header file. */
 /* #undef HAVE_WINSOCK_H */
 
+/* Define to 1 if you have the mswsock.h header file. */
+/* #undef HAVE_MSWSOCK_H */
+
+/* Define to 1 if you have the winternl.h header file. */
+/* #undef HAVE_WINTERNL_H */
+
+/* Define to 1 if you have the ntstatus.h header file. */
+/* #undef HAVE_NTSTATUS_H */
+
+/* Define to 1 if you have the ntdef.h header file. */
+/* #undef HAVE_NTDEF_H */
+
 /* Define to 1 if you have the writev function. */
-#define HAVE_WRITEV
+#define HAVE_WRITEV 1
 
 /* Define to 1 if you have the ws2tcpip.h header file. */
 /* #undef HAVE_WS2TCPIP_H */
@@ -354,14 +408,17 @@
 /* Define to 1 if you have the __system_property_get function */
 /* #undef HAVE___SYSTEM_PROPERTY_GET */
 
-/* Define to 1 if you need the malloc.h header file even with stdlib.h */
-/* #undef NEED_MALLOC_H */
+/* Define if have arc4random_buf() */
+#define HAVE_ARC4RANDOM_BUF 1
 
-/* Define to 1 if you need the memory.h header file even with stdlib.h */
-/* #undef NEED_MEMORY_H */
+/* Define if have getifaddrs() */
+#define HAVE_GETIFADDRS 1
+
+/* Define if have stat() */
+#define HAVE_STAT 1
 
 /* a suitable file/device to read random data from */
-/* #undef RANDOM_FILE */
+#define CARES_RANDOM_FILE "/dev/urandom"
 
 /* Define to the type qualifier pointed by arg 5 for recvfrom. */
 #define RECVFROM_QUAL_ARG5 
@@ -411,17 +468,11 @@
 /* Define to the function return type for recv. */
 #define RECV_TYPE_RETV ssize_t
 
-/* Define as the return type of signal handlers (`int' or `void'). */
-#define RETSIGTYPE 
-
-/* Define to the type qualifier of arg 2 for send. */
-#define SEND_QUAL_ARG2 
-
 /* Define to the type of arg 1 for send. */
 #define SEND_TYPE_ARG1 int
 
 /* Define to the type of arg 2 for send. */
-#define SEND_TYPE_ARG2 void *
+#define SEND_TYPE_ARG2 const void *
 
 /* Define to the type of arg 3 for send. */
 #define SEND_TYPE_ARG3 size_t
@@ -432,15 +483,21 @@
 /* Define to the function return type for send. */
 #define SEND_TYPE_RETV ssize_t
 
-/* Define to 1 if you can safely include both <sys/time.h> and <time.h>. */
-#define TIME_WITH_SYS_TIME
-
 /* Define to disable non-blocking sockets. */
 #undef USE_BLOCKING_SOCKETS
 
 /* Define to avoid automatic inclusion of winsock.h */
 #undef WIN32_LEAN_AND_MEAN
 
-/* Type to use in place of in_addr_t when system does not provide it. */
-#undef in_addr_t
+/* Define to 1 if you have the pthread.h header file. */
+#define HAVE_PTHREAD_H 1
+
+/* Define to 1 if you have the pthread_np.h header file. */
+/* #undef HAVE_PTHREAD_NP_H */
+
+/* Define to 1 if threads are enabled */
+#define CARES_THREADS 1
+
+/* Define to 1 if pthread_init() exists */
+/* #undef HAVE_PTHREAD_INIT */
 

--- a/Sources/CAsyncDNSResolver/include/ares_config.h
+++ b/Sources/CAsyncDNSResolver/include/ares_config.h
@@ -104,7 +104,7 @@
 #define HAVE_POLL_H 1
 
 /* Define to 1 if you have the memmem function. */
-#define HAVE_MEMMEM 1
+/* #undef HAVE_MEMMEM */
 
 /* Define to 1 if you have the poll function. */
 #define HAVE_POLL 1
@@ -354,7 +354,7 @@
 #define HAVE_SYS_PARAM_H 1
 
 /* Define to 1 if you have the <sys/random.h> header file. */
-#define HAVE_SYS_RANDOM_H 1
+/* #undef HAVE_SYS_RANDOM_H */
 
 /* Define to 1 if you have the <sys/event.h> header file. */
 /* #undef HAVE_SYS_EVENT_H */

--- a/Tests/AsyncDNSResolverTests/c-ares/AresErrorTests.swift
+++ b/Tests/AsyncDNSResolverTests/c-ares/AresErrorTests.swift
@@ -19,7 +19,7 @@ import XCTest
 
 final class AresErrorTests: XCTestCase {
     func test_initFromCode() {
-        let inputs: [Int32: AsyncDNSResolver.Error.Code] = [
+        let inputs: [ares_status_t: AsyncDNSResolver.Error.Code] = [
             ARES_EFORMERR: .badQuery,
             ARES_EBADQUERY: .badQuery,
             ARES_EBADNAME: .badQuery,
@@ -31,7 +31,7 @@ final class AresErrorTests: XCTestCase {
         ]
 
         for (code, expected) in inputs {
-            let error = AsyncDNSResolver.Error(cAresCode: code, "some error")
+            let error = AsyncDNSResolver.Error(cAresCode: Int32(code.rawValue), "some error")
             XCTAssertEqual(error.code, expected)
             XCTAssertEqual(
                 error.message,


### PR DESCRIPTION
## Summary

Updates the vendored c-ares C library from **1.19.1** to **1.34.6** (latest stable), picking up ~15 minor releases of bug fixes, security hardening, and protocol support.

## Changes

### Submodule
- `Sources/CAsyncDNSResolver/c-ares` → `v1.34.6`

### Build integration (`Package.swift`)
- c-ares 1.22+ split `src/lib` into subdirectories (`record/`, `str/`, `util/`, `dsa/`, `event/`, `legacy/`, `thirdparty/`, and an internal `src/lib/include/`). SwiftPM globs sources recursively, so this needed:
  - Added `./c-ares/src/lib/include` to the header search path.
  - Extended the `exclude` list for the two new non-source files.

### Config headers (cross-platform)
- `ares_config.h` / `ares_build.h` regenerated for 1.34.6 (hand-vendored, since SwiftPM can't run c-ares's cmake step), keeping the repo's existing `#if defined(_WIN32)` → `config-win32.h` split.
- The regenerated config was produced on macOS, which baked in Darwin-/SDK-specific answers that broke other platforms. Neutralized those in the shared POSIX section so one config builds everywhere, matching `main`'s lowest-common-denominator convention. Concretely this fixes:
  - `AvailabilityMacros.h` not found on **Linux** (`ares_rand.c`).
  - `memmem` undeclared on **Linux/glibc** (`ares_str.c`) — falls back to c-ares's portable implementation.
  - `sys/random.h` not found on **newer macOS SDKs** — falls back to `/dev/urandom`.

### `ares_status_t` migration
c-ares 1.20+ moved the status constants from `int` `#define`s into a real `ares_status_t` enum (a distinct Swift type). Bridged via an `ares_status_t(_ status: Int32)` initializer so the readable `case ARES_SUCCESS:` labels stay intact; behavior unchanged.

### Deprecated-API migration (`DNSResolver_c-ares.swift`, `AresChannel.swift`)
1.34 deprecates `ares_query`, `ares_getsock`, and all `ares_parse_*_reply` functions. Migrated to the modern API:
- **Queries:** `ares_query` → `ares_query_dnsrec`. Its callback delivers an already-parsed `ares_dns_record_t`, so the 10 reply parsers now read fields via the `ares_dns_record_rr_*` / `ares_dns_rr_get_*` accessors instead of `ares_parse_*_reply`. Each parser filters the answer section by record type (the old API filtered internally). This also removes per-parser buffer allocation and a pre-existing `hostent`/`data` leak.
- **Synchronous status:** `ares_query_dnsrec` reports a status; on failure the callback doesn't fire, so the handler is freed and the continuation failed at the call site.
- **Socket processing:** `ares_getsock` → `ARES_OPT_SOCK_STATE_CB`. `AresChannel` owns a `SocketRegistry` that the socket-state callback keeps current; `QueryProcessor` polls it to drive `ares_process_fd`. The registry's lifetime is bracketed by the channel so it stays valid across `ares_destroy`.
- Cancellation (`onCancel`) still uses `ares_cancel`, which is **not** deprecated.
