### PR TITLE
Make query cancellation per-query to avoid deadlock and cross-query cancellation

### DIFF
--- a/Sources/AsyncDNSResolver/c-ares/DNSResolver_c-ares.swift
+++ b/Sources/AsyncDNSResolver/c-ares/DNSResolver_c-ares.swift
@@ -151,11 +151,15 @@ final class Ares: Sendable {
         name: String,
         replyParser: ReplyParser
     ) async throws -> ReplyParser.Reply {
-        let channel = self.channel
+        // Created up front so both the query operation and the cancellation handler
+        // share the same per-query handler. `QueryReplyHandler` guarantees the
+        // continuation is resumed exactly once.
+        let handler = QueryReplyHandler()
         return try await withTaskCancellationHandler(
             operation: {
-                try await withCheckedThrowingContinuation { continuation in
-                    let handler = QueryReplyHandler(parser: replyParser, continuation)
+                try await withCheckedThrowingContinuation {
+                    (continuation: CheckedContinuation<ReplyParser.Reply, Error>) in
+                    handler.setContinuation(continuation, parser: replyParser)
 
                     // Wrap `handler` into a pointer so we can pass it to callback. The pointer will be deallocated in there later.
                     let handlerPointer = UnsafeMutableRawPointer.allocate(
@@ -185,9 +189,15 @@ final class Ares: Sendable {
                 }
             },
             onCancel: {
-                channel.withChannel { channel in
-                    ares_cancel(channel)
-                }
+                // Cancel only THIS query's continuation. We deliberately do NOT call
+                // `ares_cancel`: it cancels every in-flight query on the shared channel
+                // (so parallel queries would be cancelled too), and — invoked from the
+                // task-cancellation context — it races with the poll loop resuming a
+                // continuation under the channel lock, deadlocking the resolver. The
+                // c-ares request is left to finish on its own (bounded by its timeout);
+                // its callback then finds the continuation already resumed and only
+                // cleans up.
+                handler.cancel()
             }
         )
     }
@@ -275,15 +285,50 @@ extension Ares {
 
 @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension Ares {
-    class QueryReplyHandler {
-        private let _handler: (CInt, UnsafeMutablePointer<CUnsignedChar>?, CInt) -> Void
+    /// Per-query bridge between the c-ares callback / task cancellation and the
+    /// `CheckedContinuation`. Guarantees the continuation is resumed exactly once,
+    /// whichever of the two arrives first (a reply/timeout callback, or cancellation),
+    /// and always resumes outside its lock so it can never invert with the channel or
+    /// task-status locks.
+    final class QueryReplyHandler: @unchecked Sendable {
+        private let lock = NSLock()
+        private var hasResumed = false
+        private var cancelledBeforeReady = false
+        private var resumeWithReply: ((CInt, UnsafeMutablePointer<CUnsignedChar>?, CInt) -> Void)?
+        private var resumeWithCancellation: (() -> Void)?
 
-        init<Parser: AresQueryReplyParser>(parser: Parser, _ continuation: CheckedContinuation<Parser.Reply, Error>) {
-            self._handler = { status, buffer, length in
+        #if DEBUG
+        /// Test-only live-instance counter, so tests can assert that a cancelled query's
+        /// deferred c-ares work is eventually released and does not leak.
+        final class LiveCounter: @unchecked Sendable {
+            private let lock = NSLock()
+            private var count = 0
+            func increment() { self.lock.lock(); self.count += 1; self.lock.unlock() }
+            func decrement() { self.lock.lock(); self.count -= 1; self.lock.unlock() }
+            var current: Int { self.lock.lock(); defer { self.lock.unlock() }; return self.count }
+        }
+        static let liveInstances = LiveCounter()
+        init() { Self.liveInstances.increment() }
+        deinit { Self.liveInstances.decrement() }
+        #endif
+
+        /// Attach the continuation once `withCheckedThrowingContinuation` provides it.
+        /// If the task was already cancelled before this point, resume immediately.
+        func setContinuation<Parser: AresQueryReplyParser>(
+            _ continuation: CheckedContinuation<Parser.Reply, Error>,
+            parser: Parser
+        ) {
+            self.lock.lock()
+            if self.cancelledBeforeReady {
+                self.hasResumed = true
+                self.lock.unlock()
+                continuation.resume(throwing: CancellationError())
+                return
+            }
+            self.resumeWithReply = { status, buffer, length in
                 guard status == ARES_SUCCESS || status == ARES_ENODATA else {
                     return continuation.resume(throwing: AsyncDNSResolver.Error(cAresCode: status))
                 }
-
                 do {
                     let reply = try parser.parse(buffer: buffer, length: length)
                     continuation.resume(returning: reply)
@@ -291,10 +336,41 @@ extension Ares {
                     continuation.resume(throwing: error)
                 }
             }
+            self.resumeWithCancellation = { continuation.resume(throwing: CancellationError()) }
+            self.lock.unlock()
         }
 
+        /// Invoked from the c-ares callback (on the poll loop) when the query completes.
         func handle(status: CInt, buffer: UnsafeMutablePointer<CUnsignedChar>?, length: CInt) {
-            self._handler(status, buffer, length)
+            self.lock.lock()
+            guard !self.hasResumed else {
+                self.lock.unlock()
+                return
+            }
+            self.hasResumed = true
+            let resume = self.resumeWithReply
+            self.lock.unlock()
+            // Resume outside the lock: never hold `lock` across `continuation.resume`.
+            resume?(status, buffer, length)
+        }
+
+        /// Invoked from the task cancellation handler. Resumes this query's continuation
+        /// with `CancellationError` exactly once, without touching c-ares.
+        func cancel() {
+            self.lock.lock()
+            guard !self.hasResumed else {
+                self.lock.unlock()
+                return
+            }
+            guard let resume = self.resumeWithCancellation else {
+                // Cancelled before the continuation was attached; setContinuation resumes.
+                self.cancelledBeforeReady = true
+                self.lock.unlock()
+                return
+            }
+            self.hasResumed = true
+            self.lock.unlock()
+            resume()
         }
     }
 }

--- a/Sources/AsyncDNSResolver/c-ares/DNSResolver_c-ares.swift
+++ b/Sources/AsyncDNSResolver/c-ares/DNSResolver_c-ares.swift
@@ -159,9 +159,9 @@ final class Ares: Sendable {
             operation: {
                 try await withCheckedThrowingContinuation {
                     (continuation: CheckedContinuation<ReplyParser.Reply, Error>) in
-                    // If the task was already cancelled, `setContinuation` resumes with a
+                    // If the task was already cancelled, `initialize` resumes with a
                     // `CancellationError` and returns `false`, so we must not issue the request.
-                    guard handler.setContinuation(continuation, parser: replyParser) else {
+                    guard handler.initialize(continuation, parser: replyParser) else {
                         return
                     }
 
@@ -318,7 +318,7 @@ extension Ares {
 
         /// Attaches the continuation. Returns `true` if the caller should start the request,
         /// or `false` if the task was already cancelled (the continuation is resumed here).
-        func setContinuation<Parser: AresQueryReplyParser>(
+        func initialize<Parser: AresQueryReplyParser>(
             _ continuation: CheckedContinuation<Parser.Reply, Error>,
             parser: Parser
         ) -> Bool {
@@ -368,7 +368,7 @@ extension Ares {
                 return
             }
             guard let resume = self.resumeWithCancellation else {
-                // Cancelled before the continuation was attached; setContinuation resumes.
+                // Cancelled before the continuation was attached; initialize resumes.
                 self.cancelledBeforeReady = true
                 self.lock.unlock()
                 return

--- a/Sources/AsyncDNSResolver/c-ares/DNSResolver_c-ares.swift
+++ b/Sources/AsyncDNSResolver/c-ares/DNSResolver_c-ares.swift
@@ -195,8 +195,8 @@ final class Ares: Sendable {
             onCancel: {
                 // Cancel only THIS query's continuation. We deliberately do NOT call
                 // `ares_cancel`: it cancels every in-flight query on the shared channel
-                // (so parallel queries would be cancelled too), and — invoked from the
-                // task-cancellation context — it races with the poll loop resuming a
+                // (so parallel queries would be cancelled too), and, invoked from the
+                // task-cancellation context, it races with the poll loop resuming a
                 // continuation under the channel lock, deadlocking the resolver. The
                 // c-ares request is left to finish on its own (bounded by its timeout);
                 // its callback then finds the continuation already resumed and only
@@ -302,9 +302,12 @@ extension Ares {
         }
 
         private let lock = NSLock()
-        private var hasResumed = false
-        private var cancelledBeforeReady = false
+        // Set by `initialize`; read and cleared to `nil` by the first of `handle`/`cancel`.
+        // A `nil` value means the continuation has already been resumed, which enforces
+        // resume-once without a separate flag.
         private var resume: ((Outcome) -> Void)?
+        // Set only when cancellation arrives before `initialize`; consumed there.
+        private var cancelledBeforeReady = false
 
         #if DEBUG
         /// Test-only live-instance counter, so tests can assert that a cancelled query's
@@ -329,7 +332,6 @@ extension Ares {
         ) -> Bool {
             self.lock.lock()
             if self.cancelledBeforeReady {
-                self.hasResumed = true
                 self.lock.unlock()
                 continuation.resume(throwing: CancellationError())
                 return false
@@ -357,14 +359,11 @@ extension Ares {
         /// Invoked from the c-ares callback (on the poll loop) when the query completes.
         func handle(status: CInt, buffer: UnsafeMutablePointer<CUnsignedChar>?, length: CInt) {
             self.lock.lock()
-            if self.hasResumed {
-                self.lock.unlock()
-                return
-            }
-            self.hasResumed = true
             let resume = self.resume
+            self.resume = nil
             self.lock.unlock()
             // Resume outside the lock: never hold `lock` across `continuation.resume`.
+            // A `nil` resume means it has already run: nothing to do.
             resume?(.reply(status: status, buffer: buffer, length: length))
         }
 
@@ -372,19 +371,15 @@ extension Ares {
         /// with `CancellationError` exactly once, without touching c-ares.
         func cancel() {
             self.lock.lock()
-            if self.hasResumed {
-                self.lock.unlock()
-                return
-            }
-            guard let resume = self.resume else {
-                // Cancelled before the continuation was attached; initialize resumes.
+            let resume = self.resume
+            self.resume = nil
+            if resume == nil {
+                // `initialize` hasn't run yet (it resumes with cancellation when it does),
+                // or the continuation was already resumed (this flag is then never read).
                 self.cancelledBeforeReady = true
-                self.lock.unlock()
-                return
             }
-            self.hasResumed = true
             self.lock.unlock()
-            resume(.cancelled)
+            resume?(.cancelled)
         }
     }
 }

--- a/Sources/AsyncDNSResolver/c-ares/DNSResolver_c-ares.swift
+++ b/Sources/AsyncDNSResolver/c-ares/DNSResolver_c-ares.swift
@@ -315,9 +315,21 @@ extension Ares {
         final class LiveCounter: @unchecked Sendable {
             private let lock = NSLock()
             private var count = 0
-            func increment() { self.lock.lock(); self.count += 1; self.lock.unlock() }
-            func decrement() { self.lock.lock(); self.count -= 1; self.lock.unlock() }
-            var current: Int { self.lock.lock(); defer { self.lock.unlock() }; return self.count }
+            func increment() {
+                self.lock.lock()
+                self.count += 1
+                self.lock.unlock()
+            }
+            func decrement() {
+                self.lock.lock()
+                self.count -= 1
+                self.lock.unlock()
+            }
+            var current: Int {
+                self.lock.lock()
+                defer { self.lock.unlock() }
+                return self.count
+            }
         }
         static let liveInstances = LiveCounter()
         init() { Self.liveInstances.increment() }
@@ -359,8 +371,7 @@ extension Ares {
         /// Invoked from the c-ares callback (on the poll loop) when the query completes.
         func handle(status: CInt, buffer: UnsafeMutablePointer<CUnsignedChar>?, length: CInt) {
             self.lock.lock()
-            let resume = self.resume
-            self.resume = nil
+            let resume = self.resume.take()
             self.lock.unlock()
             // Resume outside the lock: never hold `lock` across `continuation.resume`.
             // A `nil` resume means it has already run: nothing to do.
@@ -371,8 +382,7 @@ extension Ares {
         /// with `CancellationError` exactly once, without touching c-ares.
         func cancel() {
             self.lock.lock()
-            let resume = self.resume
-            self.resume = nil
+            let resume = self.resume.take()
             if resume == nil {
                 // `initialize` hasn't run yet (it resumes with cancellation when it does),
                 // or the continuation was already resumed (this flag is then never read).

--- a/Sources/AsyncDNSResolver/c-ares/DNSResolver_c-ares.swift
+++ b/Sources/AsyncDNSResolver/c-ares/DNSResolver_c-ares.swift
@@ -159,7 +159,11 @@ final class Ares: Sendable {
             operation: {
                 try await withCheckedThrowingContinuation {
                     (continuation: CheckedContinuation<ReplyParser.Reply, Error>) in
-                    handler.setContinuation(continuation, parser: replyParser)
+                    // If the task was already cancelled, `setContinuation` resumes with a
+                    // `CancellationError` and returns `false`, so we must not issue the request.
+                    guard handler.setContinuation(continuation, parser: replyParser) else {
+                        return
+                    }
 
                     // Wrap `handler` into a pointer so we can pass it to callback. The pointer will be deallocated in there later.
                     let handlerPointer = UnsafeMutableRawPointer.allocate(
@@ -312,18 +316,18 @@ extension Ares {
         deinit { Self.liveInstances.decrement() }
         #endif
 
-        /// Attach the continuation once `withCheckedThrowingContinuation` provides it.
-        /// If the task was already cancelled before this point, resume immediately.
+        /// Attaches the continuation. Returns `true` if the caller should start the request,
+        /// or `false` if the task was already cancelled (the continuation is resumed here).
         func setContinuation<Parser: AresQueryReplyParser>(
             _ continuation: CheckedContinuation<Parser.Reply, Error>,
             parser: Parser
-        ) {
+        ) -> Bool {
             self.lock.lock()
             if self.cancelledBeforeReady {
                 self.hasResumed = true
                 self.lock.unlock()
                 continuation.resume(throwing: CancellationError())
-                return
+                return false
             }
             self.resumeWithReply = { status, buffer, length in
                 guard status == ARES_SUCCESS || status == ARES_ENODATA else {
@@ -338,12 +342,13 @@ extension Ares {
             }
             self.resumeWithCancellation = { continuation.resume(throwing: CancellationError()) }
             self.lock.unlock()
+            return true
         }
 
         /// Invoked from the c-ares callback (on the poll loop) when the query completes.
         func handle(status: CInt, buffer: UnsafeMutablePointer<CUnsignedChar>?, length: CInt) {
             self.lock.lock()
-            guard !self.hasResumed else {
+            if self.hasResumed {
                 self.lock.unlock()
                 return
             }
@@ -358,7 +363,7 @@ extension Ares {
         /// with `CancellationError` exactly once, without touching c-ares.
         func cancel() {
             self.lock.lock()
-            guard !self.hasResumed else {
+            if self.hasResumed {
                 self.lock.unlock()
                 return
             }

--- a/Sources/AsyncDNSResolver/c-ares/DNSResolver_c-ares.swift
+++ b/Sources/AsyncDNSResolver/c-ares/DNSResolver_c-ares.swift
@@ -295,11 +295,16 @@ extension Ares {
     /// and always resumes outside its lock so it can never invert with the channel or
     /// task-status locks.
     final class QueryReplyHandler: @unchecked Sendable {
+        /// Whichever of a c-ares reply or a task cancellation arrives first.
+        enum Outcome {
+            case reply(status: CInt, buffer: UnsafeMutablePointer<CUnsignedChar>?, length: CInt)
+            case cancelled
+        }
+
         private let lock = NSLock()
         private var hasResumed = false
         private var cancelledBeforeReady = false
-        private var resumeWithReply: ((CInt, UnsafeMutablePointer<CUnsignedChar>?, CInt) -> Void)?
-        private var resumeWithCancellation: (() -> Void)?
+        private var resume: ((Outcome) -> Void)?
 
         #if DEBUG
         /// Test-only live-instance counter, so tests can assert that a cancelled query's
@@ -329,18 +334,22 @@ extension Ares {
                 continuation.resume(throwing: CancellationError())
                 return false
             }
-            self.resumeWithReply = { status, buffer, length in
-                guard status == ARES_SUCCESS || status == ARES_ENODATA else {
-                    return continuation.resume(throwing: AsyncDNSResolver.Error(cAresCode: status))
-                }
-                do {
-                    let reply = try parser.parse(buffer: buffer, length: length)
-                    continuation.resume(returning: reply)
-                } catch {
-                    continuation.resume(throwing: error)
+            self.resume = { outcome in
+                switch outcome {
+                case .cancelled:
+                    continuation.resume(throwing: CancellationError())
+                case .reply(let status, let buffer, let length):
+                    guard status == ARES_SUCCESS || status == ARES_ENODATA else {
+                        return continuation.resume(throwing: AsyncDNSResolver.Error(cAresCode: status))
+                    }
+                    do {
+                        let reply = try parser.parse(buffer: buffer, length: length)
+                        continuation.resume(returning: reply)
+                    } catch {
+                        continuation.resume(throwing: error)
+                    }
                 }
             }
-            self.resumeWithCancellation = { continuation.resume(throwing: CancellationError()) }
             self.lock.unlock()
             return true
         }
@@ -353,10 +362,10 @@ extension Ares {
                 return
             }
             self.hasResumed = true
-            let resume = self.resumeWithReply
+            let resume = self.resume
             self.lock.unlock()
             // Resume outside the lock: never hold `lock` across `continuation.resume`.
-            resume?(status, buffer, length)
+            resume?(.reply(status: status, buffer: buffer, length: length))
         }
 
         /// Invoked from the task cancellation handler. Resumes this query's continuation
@@ -367,7 +376,7 @@ extension Ares {
                 self.lock.unlock()
                 return
             }
-            guard let resume = self.resumeWithCancellation else {
+            guard let resume = self.resume else {
                 // Cancelled before the continuation was attached; initialize resumes.
                 self.cancelledBeforeReady = true
                 self.lock.unlock()
@@ -375,7 +384,7 @@ extension Ares {
             }
             self.hasResumed = true
             self.lock.unlock()
-            resume()
+            resume(.cancelled)
         }
     }
 }

--- a/Tests/AsyncDNSResolverTests/c-ares/CAresCancellationTests.swift
+++ b/Tests/AsyncDNSResolverTests/c-ares/CAresCancellationTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftAsyncDNSResolver open source project
 //
-// Copyright (c) 2020-2026 Apple Inc. and the SwiftAsyncDNSResolver project authors
+// Copyright (c) 2026 Apple Inc. and the SwiftAsyncDNSResolver project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information

--- a/Tests/AsyncDNSResolverTests/c-ares/CAresCancellationTests.swift
+++ b/Tests/AsyncDNSResolverTests/c-ares/CAresCancellationTests.swift
@@ -1,0 +1,175 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftAsyncDNSResolver open source project
+//
+// Copyright (c) 2020-2026 Apple Inc. and the SwiftAsyncDNSResolver project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftAsyncDNSResolver project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+
+@testable import AsyncDNSResolver
+
+/// Cancellation is per-query: cancelling the task awaiting one query resumes only that
+/// query's continuation (with `CancellationError`) and never calls `ares_cancel`, so it
+/// neither deadlocks against the poll loop nor cancels other in-flight queries sharing
+/// the channel.
+final class CAresCancellationTests: XCTestCase {
+    /// Reserved, non-routable (TEST-NET-1, RFC 5737): queries never get an answer, so
+    /// they stay in flight until we cancel them or they time out.
+    private static let blackholeServer = "192.0.2.1"
+
+    private func makeResolver(timeoutMillis: Int32 = 5000) throws -> CAresDNSResolver {
+        var options = CAresDNSResolver.Options()
+        options.servers = [Self.blackholeServer]
+        options.timeoutMillis = timeoutMillis
+        return try CAresDNSResolver(options: options)
+    }
+
+    /// Race-style: repeatedly start an in-flight query and cancel it from another task
+    /// while the resolver is polling. Each cancel must settle promptly with
+    /// `CancellationError` — a cancel that re-entered the locked resolver state / inverted
+    /// with the poll loop would hang and trip the watchdog.
+    func test_cancelInFlightQuery_isRaceSafeAndSettlesWithoutDeadlock() async throws {
+        let resolver = try self.makeResolver()
+        for iteration in 0..<25 {
+            let query = Task { try await resolver.queryA(name: "example.com") }
+
+            // Cancel from a SEPARATE task, concurrently with the poll loop — after a
+            // small, varied delay so the cancel lands while the query is in flight.
+            let canceller = Task {
+                try? await Task.sleep(nanoseconds: UInt64(5_000_000 + iteration % 5 * 3_000_000))
+                query.cancel()
+            }
+
+            let outcome = await Self.result(of: { try await query.value }, within: 5_000_000_000)
+            canceller.cancel()
+            switch outcome {
+            case .none:
+                XCTFail("iteration \(iteration): cancelled query did not settle within 5s — likely a deadlock")
+                return
+            case .some(.success):
+                XCTFail("iteration \(iteration): cancelled query unexpectedly succeeded")
+                return
+            case .some(.failure(let error)):
+                XCTAssertTrue(error is CancellationError, "iteration \(iteration): expected CancellationError, got \(error)")
+            }
+        }
+    }
+
+    /// Cancelling one query must NOT cancel a parallel query sharing the same channel.
+    /// With the old `ares_cancel(channel)` approach this failed: cancelling A cancelled
+    /// every in-flight query on the channel, so B would settle immediately too.
+    func test_cancellingOneQueryDoesNotCancelParallelQueryOnSameChannel() async throws {
+        let resolver = try self.makeResolver()
+
+        // B records when it finishes, so we can assert it stays in flight without
+        // awaiting its value (which isn't a cancellation point).
+        let bFinished = AtomicFlag()
+        let queryA = Task { try await resolver.queryA(name: "a.example.com") }
+        let queryB = Task { () -> [ARecord] in
+            defer { bFinished.set() }
+            return try await resolver.queryA(name: "b.example.com")
+        }
+
+        // Ensure both queries are in flight on the shared channel.
+        try await Task.sleep(nanoseconds: 150_000_000)
+
+        // Cancel only A — it must settle with CancellationError.
+        queryA.cancel()
+        let aOutcome = await Self.result(of: { try await queryA.value }, within: 5_000_000_000)
+        if case .some(.failure(let error)) = aOutcome {
+            XCTAssertTrue(error is CancellationError, "A should be cancelled, got \(error)")
+        } else {
+            XCTFail("A did not settle with CancellationError after cancel")
+        }
+
+        // Give any (incorrect) cross-query cancellation a chance to land, then assert B
+        // is still in flight. On the old ares_cancel(channel) approach B would already
+        // have been cancelled here.
+        try await Task.sleep(nanoseconds: 300_000_000)
+        XCTAssertFalse(
+            bFinished.value,
+            "cancelling A also finished B — the cancel leaked across queries on the shared channel"
+        )
+
+        // Cleanup: cancel B (settles fast via per-query cancel; no wait on its timeout).
+        queryB.cancel()
+        _ = try? await queryB.value
+    }
+
+    /// Minimal thread-safe boolean flag for test synchronization.
+    private final class AtomicFlag: @unchecked Sendable {
+        private let lock = NSLock()
+        private var flag = false
+        func set() { self.lock.lock(); self.flag = true; self.lock.unlock() }
+        var value: Bool { self.lock.lock(); defer { self.lock.unlock() }; return self.flag }
+    }
+
+    #if DEBUG
+    /// A cancelled query's deferred c-ares work must be released, not leaked: the caller
+    /// is resumed immediately, and once the background request finishes on its own its
+    /// per-query handler is deallocated.
+    func test_cancelledQueryReleasesResourcesAndDoesNotLeak() async throws {
+        // Handlers left draining by earlier tests share this global counter, so first wait
+        // for it to quiesce (two consecutive equal reads) to get a stable baseline.
+        var baseline = Ares.QueryReplyHandler.liveInstances.current
+        for _ in 0..<100 {
+            try await Task.sleep(nanoseconds: 100_000_000)
+            let current = Ares.QueryReplyHandler.liveInstances.current
+            if current == baseline { break }
+            baseline = current
+        }
+
+        // Short timeout so the abandoned background request drains quickly.
+        let resolver = try self.makeResolver(timeoutMillis: 1000)
+
+        let query = Task { try await resolver.queryA(name: "example.com") }
+        try await Task.sleep(nanoseconds: 100_000_000)
+        XCTAssertGreaterThan(
+            Ares.QueryReplyHandler.liveInstances.current, baseline,
+            "handler should be alive while the query is in flight"
+        )
+        query.cancel()
+        _ = try? await query.value  // caller unblocked immediately with CancellationError
+
+        // The c-ares request keeps running in the background; when it completes (bounded by
+        // the timeout) its callback releases the handler. Poll until we're back to baseline.
+        var released = false
+        for _ in 0..<100 {  // up to ~10s
+            if Ares.QueryReplyHandler.liveInstances.current <= baseline {
+                released = true
+                break
+            }
+            try await Task.sleep(nanoseconds: 100_000_000)
+        }
+        XCTAssertTrue(released, "cancelled query's handler was never released — deferred work leaked")
+    }
+    #endif
+
+    /// Runs `operation`, returning its `Result` if it finishes within `nanos`, or `nil`
+    /// if a watchdog fires first (i.e. it is still running).
+    private static func result<T: Sendable>(
+        of operation: @escaping @Sendable () async throws -> T,
+        within nanos: UInt64
+    ) async -> Result<T, Error>? {
+        await withTaskGroup(of: Result<T, Error>?.self) { group in
+            group.addTask {
+                do { return .success(try await operation()) } catch { return .failure(error) }
+            }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: nanos)
+                return nil
+            }
+            let first = await group.next() ?? nil
+            group.cancelAll()
+            return first
+        }
+    }
+}

--- a/Tests/AsyncDNSResolverTests/c-ares/CAresCancellationTests.swift
+++ b/Tests/AsyncDNSResolverTests/c-ares/CAresCancellationTests.swift
@@ -34,8 +34,8 @@ final class CAresCancellationTests: XCTestCase {
 
     /// Race-style: repeatedly start an in-flight query and cancel it from another task
     /// while the resolver is polling. Each cancel must settle promptly with
-    /// `CancellationError` — a cancel that re-entered the locked resolver state / inverted
-    /// with the poll loop would hang and trip the watchdog.
+    /// `CancellationError`. A cancel that re-entered the locked resolver state / inverted
+    /// with the poll loop would deadlock and trip the watchdog.
     func test_cancelInFlightQuery_isRaceSafeAndSettlesWithoutDeadlock() async throws {
         let resolver = try self.makeResolver()
         for iteration in 0..<25 {
@@ -58,7 +58,10 @@ final class CAresCancellationTests: XCTestCase {
                 XCTFail("iteration \(iteration): cancelled query unexpectedly succeeded")
                 return
             case .some(.failure(let error)):
-                XCTAssertTrue(error is CancellationError, "iteration \(iteration): expected CancellationError, got \(error)")
+                XCTAssertTrue(
+                    error is CancellationError,
+                    "iteration \(iteration): expected CancellationError, got \(error)"
+                )
             }
         }
     }
@@ -108,8 +111,16 @@ final class CAresCancellationTests: XCTestCase {
     private final class AtomicFlag: @unchecked Sendable {
         private let lock = NSLock()
         private var flag = false
-        func set() { self.lock.lock(); self.flag = true; self.lock.unlock() }
-        var value: Bool { self.lock.lock(); defer { self.lock.unlock() }; return self.flag }
+        func set() {
+            self.lock.lock()
+            self.flag = true
+            self.lock.unlock()
+        }
+        var value: Bool {
+            self.lock.lock()
+            defer { self.lock.unlock() }
+            return self.flag
+        }
     }
 
     #if DEBUG
@@ -133,7 +144,8 @@ final class CAresCancellationTests: XCTestCase {
         let query = Task { try await resolver.queryA(name: "example.com") }
         try await Task.sleep(nanoseconds: 100_000_000)
         XCTAssertGreaterThan(
-            Ares.QueryReplyHandler.liveInstances.current, baseline,
+            Ares.QueryReplyHandler.liveInstances.current,
+            baseline,
             "handler should be alive while the query is in flight"
         )
         query.cancel()


### PR DESCRIPTION
## Problem

Cancelling an in-flight query called `ares_cancel` from the task cancellation
handler. That has two problems:

1. `ares_cancel` cancels **every** query on the shared channel, so parallel
   queries on the same resolver were cancelled too.
2. Taking the channel lock from the cancellation context races with the poll
   loop, which holds that same lock while resuming a continuation — an ABBA
   inversion that deadlocks the resolver.

c-ares has no per-query cancellation API (even in 1.34.x), so cancelling a
single query at the c-ares level isn't possible.

## Fix

Decouple task cancellation from the c-ares request:

- On cancel, resume only **this** query's continuation with `CancellationError`.
- Leave the c-ares request to finish on its own (bounded by its timeout); when
  its callback fires it finds the continuation already resumed and just cleans
  up.
- `QueryReplyHandler` guards a single resume shared between the reply callback
  and cancellation, always resuming outside its lock — so it can't invert with
  the channel or task-status locks.

**Tradeoff:** the cancelled request's c-ares resources linger until its timeout
rather than being freed immediately. Freeing a single request early isn't
possible with `ares_cancel` (channel-wide) short of one channel per query,
which seemed like too much overhead — happy to reconsider.

## Tests

- **race / no re-entry:** repeatedly cancel an in-flight query while the resolver
  polls; each settles promptly with `CancellationError`.
- **cross-query:** cancelling one query does not cancel a parallel query on the
  same channel.
- **no leak:** a cancelled query's deferred c-ares work is released once the
  background request completes (DEBUG live-instance counter).
